### PR TITLE
Fix order of parameters passed to MainWPUtility::fetchUrl()

### DIFF
--- a/class/MainWPUtility.class.php
+++ b/class/MainWPUtility.class.php
@@ -631,7 +631,7 @@ class MainWPUtility
     {
         $postdata = MainWPUtility::getPostDataNotAuthed($url, $admin, $what, $params);
         $website = null;
-        return MainWPUtility::fetchUrl($website, $url, $postdata, $pForceFetch, false, $verifyCertificate, $http_user, $http_pass);
+        return MainWPUtility::fetchUrl($website, $url, $postdata, false, $pForceFetch, $verifyCertificate, true, $http_user, $http_pass);
     }
 
     static function fetchUrlClean($url, $postdata)


### PR DESCRIPTION
Without this fix, it's impossible to to add a site if it has HTTP Authentication (CURLOPT_USERPWD is incorrectly generated).