### PR TITLE
Fixed a variable naming issue that throws a ReferenceError when using…

### DIFF
--- a/js/mainwp.js
+++ b/js/mainwp.js
@@ -6959,7 +6959,7 @@ mainwp_managesites_bulk_remove_specific  = function (pCheckedBox) {
         }
 
         if (error != '') {
-            err = '<div class="mainwp_info-box-red mainwp_append_error">' + err + '</div>';
+            err = '<div class="mainwp_info-box-red mainwp_append_error">' + error + '</div>';
             jQuery('#mainwp_managesites_add_other_message').after(err);
         }
         //if (error == '') {


### PR DESCRIPTION
… the mainwp_managesites_bulk_remove_specific function
![screen shot 2016-05-20 at 5 23 46 pm](https://cloud.githubusercontent.com/assets/6192474/15443670/be21298c-1eaf-11e6-8cfa-d2536e697fce.png)
![screen shot 2016-05-20 at 4 51 09 pm](https://cloud.githubusercontent.com/assets/6192474/15443672/be268c92-1eaf-11e6-8f46-5a98bb24d485.png)
![screen shot 2016-05-20 at 4 50 43 pm](https://cloud.githubusercontent.com/assets/6192474/15443671/be23523e-1eaf-11e6-890c-545bfe0284d7.png)


