### PR TITLE
Add a filter to post_data in the bulk post function, to match the bulk page post function

### DIFF
--- a/page/page-mainwp-post.php
+++ b/page/page-mainwp-post.php
@@ -869,6 +869,7 @@ class MainWP_Post {
 								'post_gallery_images' => base64_encode( serialize( $post_gallery_images ) ),
 								'mainwp_upload_dir'   => base64_encode( serialize( $mainwp_upload_dir ) ),
 							);
+							$post_data = apply_filters( 'mainwp_bulkpost_posting', $post_data, $id );
 							MainWP_Utility::fetchUrlsAuthed( $dbwebsites, 'newpost', $post_data, array(
 								MainWP_Bulk_Add::getClassName(),
 								'PostingBulk_handler',


### PR DESCRIPTION
There is a filter applied in page-mainwp-page.php that allows developers to hook into the post data before it is sent to child sites. However, there is no corresponding filter in page-mainwp-page.php. I propose adding a filter to create symmetry between the two post types.