### PR TITLE
Fix changelog url

### DIFF
--- a/widget/widget-mainwp-right-now.php
+++ b/widget/widget-mainwp-right-now.php
@@ -1283,13 +1283,13 @@ class MainWP_Right_Now {
 								<div class="mainwp-sub-row" plugin_slug="<?php echo $plugin_name; ?>" premium="<?php echo ( isset( $plugin_upgrade['premium'] ) ? $plugin_upgrade['premium'] : 0 ) ? 1 : 0; ?>" updated="0">
 									<div class="mainwp-left mainwp-padding-top-5 mainwp-cols-3">
 										<?php if ( $globalView ) { ?>&nbsp;&nbsp;&nbsp;<?php } ?><?php if (in_array( $slug, $trustedPlugins)) { echo $trusted_icon; } ; ?>
-										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_upgrade['update']['slug'] . '&url=' . ( isset( $plugin_upgrade['PluginURI'] ) ? rawurlencode( $plugin_upgrade['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_upgrade['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox" title="More information about <?php echo $plugin_upgrade['Name']; ?>">
+										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_upgrade['update']['slug'] . '&url=' . ( isset( $plugin_upgrade['PluginURI'] ) ? rawurlencode( $plugin_upgrade['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_upgrade['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="More information about <?php echo $plugin_upgrade['Name']; ?>">
 											<?php echo $plugin_upgrade['Name']; ?>
 										</a>
 										<input type="hidden" id="wp_upgraded_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>" value="0"/>
 									</div>
 									<div class="mainwp-left mainwp-padding-top-5 mainwp-cols-5 pluginsInfo" id="wp_upgrade_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>">
-										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_upgrade['update']['slug'] . '&url=' . ( isset( $plugin_upgrade['PluginURI'] ) ? rawurlencode( $plugin_upgrade['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_upgrade['Name'] ) . '&TB_iframe=true&width=640&height=477&section=changelog'; ?>" target="_blank" class="thickbox" title="Changelog <?php echo $plugin_upgrade['Name']; ?>">
+										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_upgrade['update']['slug'] . '&url=' . ( isset( $plugin_upgrade['PluginURI'] ) ? rawurlencode( $plugin_upgrade['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_upgrade['Name'] ) . '&section=changelog&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="Changelog <?php echo $plugin_upgrade['Name']; ?>">
 											<?php echo $plugin_upgrade['Version']; ?> to <?php echo $plugin_upgrade['update']['new_version']; ?>
 										</a>
 									</div>
@@ -1418,7 +1418,7 @@ class MainWP_Right_Now {
                                                                         <div class="mainwp-sub-row" plugin_slug="<?php echo $plugin_name; ?>" premium="<?php echo ( isset( $plugin_upgrade['premium'] ) ? $plugin_upgrade['premium'] : 0 ) ? 1 : 0; ?>" updated="0">
                                                                                 <div class="mainwp-left mainwp-padding-top-5 mainwp-cols-3">
                                                                                         &nbsp;&nbsp;&nbsp;<?php if (in_array($slug, $trustedPlugins)) { echo $trusted_icon; } ; ?>
-                                                                                        <a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_upgrade['update']['slug'] . '&url=' . ( isset( $plugin_upgrade['PluginURI'] ) ? rawurlencode( $plugin_upgrade['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_upgrade['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox" title="More information about <?php echo $plugin_upgrade['Name']; ?>">
+                                                                                        <a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_upgrade['update']['slug'] . '&url=' . ( isset( $plugin_upgrade['PluginURI'] ) ? rawurlencode( $plugin_upgrade['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_upgrade['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="More information about <?php echo $plugin_upgrade['Name']; ?>">
                                                                                                 <?php echo $plugin_upgrade['Name']; ?>
                                                                                         </a>
                                                                                         <input type="hidden" id="wp_upgraded_plugin_<?php echo $website->id; ?>_group_<?php echo $group_id; ?>_<?php echo $plugin_name; ?>" value="0"/>
@@ -1474,7 +1474,7 @@ class MainWP_Right_Now {
 								<div class="mainwp-left mainwp-cols-3 mainwp-padding-top-5">
                                     <?php if (in_array($slug, $trustedPlugins)) { echo $trusted_icon; } ; ?>
 									<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $pluginsInfo[ $slug ]['slug'] . '&url=' . ( isset( $pluginsInfo[ $slug ]['uri'] ) ? rawurlencode( $pluginsInfo[ $slug ]['uri'] ) : '' ) . '&name=' . rawurlencode( $pluginsInfo[ $slug ]['name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
-									   class="thickbox" title="More information about <?php echo $pluginsInfo[ $slug ]['name']; ?>">
+									   class="thickbox open-plugin-details-modal" title="More information about <?php echo $pluginsInfo[ $slug ]['name']; ?>">
 										<?php echo $pluginsInfo[ $slug ]['name']; ?>
 									</a>
 								</div>
@@ -1541,14 +1541,14 @@ class MainWP_Right_Now {
 										<?php } else { ?>
                                             <?php if (in_array($slug, $trustedPlugins)) { echo $trusted_icon; } ; ?>
 											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $pluginsInfo[ $slug ]['slug'] . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
-											   class="thickbox" title="More information about <?php echo $pluginsInfo[ $slug ]['name']; ?>">
+											   class="thickbox open-plugin-details-modal" title="More information about <?php echo $pluginsInfo[ $slug ]['name']; ?>">
 												<?php echo $pluginsInfo[ $slug ]['name']; ?>
 											</a>
 										<?php } ?>
 									</div>
 									<div class="mainwp-left mainwp-padding-top-5 mainwp-cols-5 pluginsInfo">
-										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $pluginsInfo[ $slug ]['slug'] . '&TB_iframe=true&width=640&height=477&section=changelog'; ?>" target="_blank"
-											   class="thickbox" title="Changelog <?php echo $pluginsInfo[ $slug ]['name']; ?>">
+										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . $pluginsInfo[ $slug ]['slug'] . '&section=changelog&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
+											   class="thickbox open-plugin-details-modal" title="Changelog <?php echo $pluginsInfo[ $slug ]['name']; ?>">
 											<?php echo $plugin_upgrade['Version']; ?> to <?php echo $plugin_upgrade['update']['new_version']; ?>
 										</a>
 									</div>
@@ -2349,11 +2349,11 @@ class MainWP_Right_Now {
 										<div class="mainwp-left mainwp-cols-3">
 											<?php if ( $globalView ) { ?>&nbsp;&nbsp;&nbsp;<?php } ?>
 											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&url=' . ( isset( $plugin_outdate['PluginURI'] ) ? rawurlencode( $plugin_outdate['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_outdate['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
-											   class="thickbox" title="More information about <?php echo $plugin_outdate['Name']; ?>"><?php echo $plugin_outdate['Name']; ?></a><input type="hidden" id="wp_dismissed_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>" value="0"/>
+											   class="thickbox open-plugin-details-modal" title="More information about <?php echo $plugin_outdate['Name']; ?>"><?php echo $plugin_outdate['Name']; ?></a><input type="hidden" id="wp_dismissed_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>" value="0"/>
 										</div>
 										<div class="mainwp-left mainwp-cols-3 pluginsInfo" id="wp_outdate_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>">
-											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&url=' . ( isset( $plugin_outdate['PluginURI'] ) ? rawurlencode( $plugin_outdate['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_outdate['Name'] ) . '&TB_iframe=true&width=640&height=477&section=changelog'; ?>" target="_blank"
-											   class="thickbox" title="Changelog <?php echo $plugin_outdate['Name']; ?>">
+											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&url=' . ( isset( $plugin_outdate['PluginURI'] ) ? rawurlencode( $plugin_outdate['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_outdate['Name'] ) . '&section=changelog&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
+											   class="thickbox open-plugin-details-modal" title="Changelog <?php echo $plugin_outdate['Name']; ?>">
 												<?php echo $plugin_outdate['Version']; ?> | <?php echo $outdate_notice; ?>
 											</a>
 										</div>
@@ -2464,7 +2464,7 @@ class MainWP_Right_Now {
 										<div class="mainwp-left mainwp-cols-3">
 											&nbsp;&nbsp;&nbsp;&nbsp;
 											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&url=' . ( isset( $plugin_outdate['PluginURI'] ) ? rawurlencode( $plugin_outdate['PluginURI'] ) : '' ) . '&name=' . rawurlencode( $plugin_outdate['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
-											   class="thickbox" title="More information about <?php echo $plugin_outdate['Name']; ?>"><?php echo $plugin_outdate['Name']; ?></a><input type="hidden" id="wp_dismissed_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>" value="0"/>
+											   class="thickbox open-plugin-details-modal" title="More information about <?php echo $plugin_outdate['Name']; ?>"><?php echo $plugin_outdate['Name']; ?></a><input type="hidden" id="wp_dismissed_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>" value="0"/>
 										</div>
 										<div class="mainwp-left mainwp-cols-3 pluginsInfo" id="wp_outdate_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>">
 											<?php echo $plugin_outdate['Version']; ?> | <?php echo $outdate_notice; ?>
@@ -2511,7 +2511,7 @@ class MainWP_Right_Now {
 								<div class="mainwp-sub-row">
 									<div class="mainwp-left mainwp-cols-3">
 										<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&url=' . ( isset( $pluginsOutdateInfo[ $slug ]['uri-'] ) ? rawurlencode( $pluginsOutdateInfo[ $slug ]['uri'] ) : '' ) . '&name=' . rawurlencode( $pluginsOutdateInfo[ $slug ]['Name'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
-										   class="thickbox" title="More information about <?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>">
+										   class="thickbox open-plugin-details-modal" title="More information about <?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>">
 											<?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>
 										</a>
 									</div>
@@ -2570,14 +2570,14 @@ class MainWP_Right_Now {
 												<a href="<?php echo admin_url( 'admin.php?page=managesites&dashboard=' . $website->id ); ?>" title="<?php echo esc_attr($visit_dashboard_title);?>"><?php echo stripslashes( $website->name ); ?></a>
 											<?php } else { ?>
 												<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
-												   class="thickbox" title="More information about <?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>">
+												   class="thickbox open-plugin-details-modal" title="More information about <?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>">
 													<?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>
 												</a>
 											<?php } ?>
 										</div>
 										<div class="mainwp-left mainwp-cols-3 pluginsInfo" id="wp_outdate_plugin_<?php echo $website->id; ?>_<?php echo $plugin_name; ?>">
-											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&TB_iframe=true&width=640&height=477&section=changelog'; ?>" target="_blank"
-												   class="thickbox" title="Changelog about <?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>">
+											<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $slug ) . '&section=changelog&TB_iframe=true&width=640&height=477'; ?>" target="_blank"
+												   class="thickbox open-plugin-details-modal" title="Changelog about <?php echo $pluginsOutdateInfo[ $slug ]['Name']; ?>">
 												<?php echo $plugin_outdate['Version']; ?> | <?php echo $outdate_notice; ?>
 											</a>
 										</div>

--- a/widget/widget-mainwp-widget-plugins.php
+++ b/widget/widget-mainwp-widget-plugins.php
@@ -121,10 +121,10 @@ class MainWP_Widget_Plugins {
 						<input class="pluginSlug" type="hidden" name="slug" value="<?php echo $actived_plugins[ $i ]['slug']; ?>"/>
 						<input class="websiteId" type="hidden" name="id" value="<?php echo $website->id; ?>"/>
 						<span class="mainwp-left mainwp-cols-2">
-							<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $actived_plugins[ $i ]['slug'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox" title="More information about <?php echo $actived_plugins[ $i ]['name']; ?>">
+							<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $actived_plugins[ $i ]['slug'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="More information about <?php echo $actived_plugins[ $i ]['name']; ?>">
 								<?php echo $actived_plugins[ $i ]['name']; ?>
 							</a>
-							<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $actived_plugins[ $i ]['slug'] ) . '&TB_iframe=true&width=640&height=477&section=changelog'; ?>" target="_blank" class="thickbox" title="Changelog <?php echo $actived_plugins[ $i ]['name']; ?>">
+							<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $actived_plugins[ $i ]['slug'] ) . '&section=changelog&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="Changelog <?php echo $actived_plugins[ $i ]['name']; ?>">
 								<?php echo ' ' . $actived_plugins[ $i ]['version']; ?>
 							</a><br /><span class="mainwp-small"><?php echo $outdate_notice; ?></span>
 						</span>
@@ -162,10 +162,10 @@ class MainWP_Widget_Plugins {
 						<input class="pluginSlug" type="hidden" name="slug" value="<?php echo $inactive_plugins[ $i ]['slug']; ?>"/>
 						<input class="websiteId" type="hidden" name="id" value="<?php echo $website->id; ?>"/>
 						<span class="mainwp-left mainwp-cols-2">
-						<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $inactive_plugins[ $i ]['slug'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox" title="More information about <?php echo $inactive_plugins[ $i ]['name']; ?>">
+						<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $inactive_plugins[ $i ]['slug'] ) . '&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="More information about <?php echo $inactive_plugins[ $i ]['name']; ?>">
 							<?php echo $inactive_plugins[ $i ]['name']; ?>
 						</a>
-						<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $inactive_plugins[ $i ]['slug'] ) . '&TB_iframe=true&width=640&height=477&section=changelog'; ?>" target="_blank" class="thickbox" title="Changelog <?php echo $inactive_plugins[ $i ]['name']; ?>">
+						<a href="<?php echo admin_url() . 'plugin-install.php?tab=plugin-information&plugin=' . dirname( $inactive_plugins[ $i ]['slug'] ) . '&section=changelog&TB_iframe=true&width=640&height=477'; ?>" target="_blank" class="thickbox open-plugin-details-modal" title="Changelog <?php echo $inactive_plugins[ $i ]['name']; ?>">
 							<?php echo ' ' . $inactive_plugins[ $i ]['version']; ?>
 						</a><br /><span class="mainwp-small"><?php echo $outdate_notice; ?></span>
 						</span>


### PR DESCRIPTION
I'm sorry, in https://github.com/mainwp/mainwp/pull/41 I appended section=changelog to the end of url, but I noticed today when I updated mainwp dashboard that it didn't work as I expected.
In my local version it worked...so I checked the code and I found that In my local copy I added the "section=changelog" just after the plugin name...
I don't know why but if it is appended to the end of the url it don't open the changelog (only with iframe).

I fixed the error...

I have one note:
In this commit I also added the 'open-plugin-details-modal' class to every a tag that points to plugin details (according to https://core.trac.wordpress.org/changeset/36964 )

@ruben- 
What do you think to increment also a little bit the dialog size? something like &width=600&height=550  (wordpress use this dimension in its links, ex. https://github.com/WordPress/WordPress/blob/0ff0dcc7dedbcbbe930e96ac34609782e866a227/wp-admin/includes/class-wp-plugins-list-table.php#L785)?
The window should looks better
If you want I can do that in this pull request