### PR TITLE
Allow 0 as a non-default value on CSV import

### DIFF
--- a/view/view-mainwp-manage-sites-view.php
+++ b/view/view-mainwp-manage-sites-view.php
@@ -472,7 +472,7 @@ class MainWP_Manage_Sites_View {
 										}
 									}
 								}
-								if ( empty( $val ) ) {
+								if ( is_null( $val ) ) {
 									$val = $default[$x];
 								}
 								$line .= $val;


### PR DESCRIPTION
When importing sites from CSV, checking `$val` with `empty()` replaces the 0 value with the default (1) because `empty()` returns true for both 0 and '0'. This means that all imported sites will verify SSL certs, regardless of what is set in the CSV file.