### PR TITLE
[i18n] Correct Setup Wizard timeline alignment for long titles

### DIFF
--- a/css/mainwp-setup.css
+++ b/css/mainwp-setup.css
@@ -237,7 +237,8 @@ body {
     margin: 0;
     list-style: none;
     overflow: hidden;
-    color: #ccc
+    color: #ccc;
+    display: flex
 }
 .mwp-setup-steps li {
     width: 11%;


### PR DESCRIPTION
Solves Issue https://github.com/mainwp/mainwp/issues/82

![screenshot 2018-04-11 09 20 54](https://user-images.githubusercontent.com/7371591/38605083-412b9f9e-3d6a-11e8-902c-b59280b8e1b8.png)
