### PR TITLE
remove __autoload()

### DIFF
--- a/mainwp.php
+++ b/mainwp.php
@@ -39,13 +39,7 @@ if ( ! function_exists( 'mainwp_autoload' ) ) {
 	}
 }
 
-if ( function_exists( 'spl_autoload_register' ) ) {
-	spl_autoload_register( 'mainwp_autoload' );
-} else {
-	function __autoload( $class_name ) {
-		mainwp_autoload( $class_name );
-	}
-}
+spl_autoload_register( 'mainwp_autoload' );
 
 if ( ! function_exists( 'mainwpdir' ) ) {
 	function mainwpdir() {


### PR DESCRIPTION
the replacement for __autoload() is spl_autoload_register (http://php.net/manual/de/function.spl-autoload-register.php) which is supported in PHP >= ❗️5.1 ❗️  
No need to use it for sooooo long.