### PR TITLE
Prefix "Server" slug to ServerInformation subpages

### DIFF
--- a/pages/page-mainwp-server-information.php
+++ b/pages/page-mainwp-server-information.php
@@ -165,7 +165,7 @@ class MainWP_Server_Information {
 			}
 		}
 
-		MainWP_Menu::init_subpages_left_menu( $subPages, $init_sub_subleftmenu, 'ServerInformation', 'Settings' );
+		MainWP_Menu::init_subpages_left_menu( $subPages, $init_sub_subleftmenu, 'ServerInformation', 'Server' );
 		foreach ( $init_sub_subleftmenu as $item ) {
 			if ( MainWP_Menu::is_disable_menu_item( 3, $item['slug'] ) ) {
 				continue;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Custom Subpages are prefixed with "Server" slug, but in the `init_subpages_left_menu` the slug "Settings" was used.

Now using the "mainwp-getsubpages-server" filter one can actually access the custom Server pages.

### How to test the changes in this Pull Request:

1. Add custom page using "mainwp-getsubpages-server" filter (see code example below)
2. Under Status your page is now visible and accessable.

### Other information:

Code example:

```
add_filter( 'mainwp-getsubpages-server', function($subPages) {
	$subPages[] = [
		'slug' => 'ActionLogs',
		'title' => __( 'Action logs', 'mainwp' ),
		'callback' => [ 'MainWP_Server_Information', 'renderActionLogs'],
		'menu_hidden' => false,
	];
	return $subPages;
});
```

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Custom Subpages are prefixed with "Server" slug, but in the `init_subpages_left_menu` the slug "Settings" was used.
> 
> Now using the "mainwp-getsubpages-server" filter one can actually access the custom Server pages.