### PR TITLE
Line Ending Attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,8 @@ LICENSE.txt export-ignore
 README.md export-ignore
 phpunit.xml.dist export-ignore
 phpdoc.dist.xml export-ignore
+
+# force everything to have Unix-style line endings (LF), except for Windows batch files that require CRLF:
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Addition to .gitattributes to Force everything to have Unix-style line endings (LF), except for Windows batch files that require CRLF:

Helpful for Windows Developers & VSCode WSL Environments.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Addition to .gitattributes