### PR TITLE
Fix typo in variable naming

### DIFF
--- a/class/class-mainwp-db-common.php
+++ b/class/class-mainwp-db-common.php
@@ -848,8 +848,8 @@ class MainWP_DB_Common extends MainWP_DB {
 		}
 
 		if ( isset( $data['monitoring_emails'] ) ) {
-			$moniroting_emails = MainWP_Utility::valid_input_emails( $data['monitoring_emails'] );
-			MainWP_DB::instance()->update_website_option( $website, 'monitoring_notification_emails', $moniroting_emails );
+			$monitoring_emails = MainWP_Utility::valid_input_emails( $data['monitoring_emails'] );
+			MainWP_DB::instance()->update_website_option( $website, 'monitoring_notification_emails', $monitoring_emails );
 		}
 
 		return true;

--- a/pages/page-mainwp-manage-sites.php
+++ b/pages/page-mainwp-manage-sites.php
@@ -1454,9 +1454,9 @@ class MainWP_Manage_Sites {
 
 				MainWP_DB::instance()->update_website_values( $website->id, $newValues );
 
-				$moniroting_emails = isset( $_POST['mainwp_managesites_edit_monitoringNotificationEmails'] ) ? sanitize_text_field( wp_unslash( $_POST['mainwp_managesites_edit_monitoringNotificationEmails'] ) ) : '';
-				$moniroting_emails = MainWP_Utility::valid_input_emails( $moniroting_emails );
-				MainWP_DB::instance()->update_website_option( $website, 'monitoring_notification_emails', $moniroting_emails );
+				$monitoring_emails = isset( $_POST['mainwp_managesites_edit_monitoringNotificationEmails'] ) ? sanitize_text_field( wp_unslash( $_POST['mainwp_managesites_edit_monitoringNotificationEmails'] ) ) : '';
+				$monitoring_emails = MainWP_Utility::valid_input_emails( $monitoring_emails );
+				MainWP_DB::instance()->update_website_option( $website, 'monitoring_notification_emails', $monitoring_emails );
 				$updated = true;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix a variable naming.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
