### PR TITLE
Fixed: Last Purge Cache format to reflect WP settings.

### DIFF
--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -321,7 +321,7 @@ class MainWP_Auto_Cache_Purge_View {
 
 			// Grab UTC Timestamp and convert to local time.
 			$utc_timestamp = $last_purged;
-            
+
             // This is a format that date_create() will accept.
             $utc_timestamp_converted = gmdate( 'Y-m-d H:i:s', $utc_timestamp );
 

--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -316,13 +316,26 @@ class MainWP_Auto_Cache_Purge_View {
 		$last_purged    = isset( $site_options['mainwp_cache_control_last_purged'] ) ? $site_options['mainwp_cache_control_last_purged'] : 0;
 		$cache_solution = isset( $site_options['mainwp_cache_control_cache_solution'] ) ? $site_options['mainwp_cache_control_cache_solution'] : '';
 
-		// Display Last Purged Cache timestamp.
-		if ( ! empty( $last_purged ) ) {
-			$date_time                                = date( 'F j, Y g:ia', $last_purged ); // phpcs:ignore -- date local.
-			$item['mainwp_cache_control_last_purged'] = $date_time;
-		} else {
-			$item['mainwp_cache_control_last_purged'] = 'Never Purged';
-		}
+        // Display Last Purged Cache timestamp.
+        if ( ! empty( $last_purged ) ) {
+
+            // Grab UTC Timestamp and convert to local time.
+            $utc_timestamp = $last_purged;
+
+            // This is a format that date_create() will accept.
+            $utc_timestamp_converted = date( 'Y-m-d H:i:s', $utc_timestamp );
+
+            // Format our output.
+            $output_format = 'F j, Y g:ia';
+
+            // Now we can use our timestamp with get_date_from_gmt().
+            $local_timestamp = get_date_from_gmt( $utc_timestamp_converted, $output_format );
+
+            // Save local timestamp.
+            $item['mainwp_cache_control_last_purged'] = $local_timestamp;
+        } else {
+            $item['mainwp_cache_control_last_purged'] = 'Never Purged';
+        }
 
 		// Check if CloudFlare has been enabled & display correctly.
 		if ( ! empty( $cache_solution ) && 'Cloudflare' !== $cache_solution ) {

--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -323,7 +323,7 @@ class MainWP_Auto_Cache_Purge_View {
             $utc_timestamp = $last_purged;
 
             // This is a format that date_create() will accept.
-            $utc_timestamp_converted = date( 'Y-m-d H:i:s', $utc_timestamp );
+            $utc_timestamp_converted = gmdate( 'Y-m-d H:i:s', $utc_timestamp );
 
             // Format our output.
             $output_format = 'F j, Y g:ia';

--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -319,19 +319,13 @@ class MainWP_Auto_Cache_Purge_View {
 		// Display Last Purged Cache timestamp.
 		if ( ! empty( $last_purged ) ) {
 
-			// Grab UTC Timestamp and convert to local time.
-			$utc_timestamp = $last_purged;
+			// Grab last purged timestamp & convert UTC to GMT - This is a format that date_i18n() will accept.
+            $dt_gmt = gmdate( 'Y-m-d H:i:s', $last_purged );
 
-			// This is a format that date_create() will accept.
-			$utc_timestamp_converted = gmdate( 'Y-m-d H:i:s', $utc_timestamp );
+            // Convert GMT into chosen WP DateTime formats.
+            $local_timestamp = date_i18n(get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( get_date_from_gmt( $dt_gmt ) ) );
 
-			// Format our output.
-			$output_format = 'F j, Y g:ia';
-
-			// Now we can use our timestamp with get_date_from_gmt().
-			$local_timestamp = MainWP_Utility::format_timestamp( get_date_from_gmt( $utc_timestamp_converted, $output_format ) );
-
-			// Save local timestamp..
+            // Save local timestamp..
 			$item['mainwp_cache_control_last_purged'] = $local_timestamp;
 		} else {
 			$item['mainwp_cache_control_last_purged'] = 'Never Purged';

--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -319,14 +319,14 @@ class MainWP_Auto_Cache_Purge_View {
 		// Display Last Purged Cache timestamp.
 		if ( ! empty( $last_purged ) ) {
 
-            // Grab last purged timestamp & convert UTC to GMT - This is a format that date_i18n() will accept.
-            $dt_gmt = gmdate( 'Y-m-d H:i:s', $last_purged );
+			// Grab last purged timestamp & convert UTC to GMT - This is a format that date_i18n() will accept.
+			$dt_gmt = gmdate( 'Y-m-d H:i:s', $last_purged );
 
-            // Convert GMT into chosen WP DateTime formats.
-            $local_timestamp = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( get_date_from_gmt( $dt_gmt ) ) );
+			// Convert GMT into chosen WP DateTime formats.
+			$local_timestamp = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( get_date_from_gmt( $dt_gmt ) ) );
 
-            // Save local timestamp..
-            $item['mainwp_cache_control_last_purged'] = $local_timestamp;
+			// Save local timestamp..
+			$item['mainwp_cache_control_last_purged'] = $local_timestamp;
 		} else {
 			$item['mainwp_cache_control_last_purged'] = 'Never Purged';
 		}

--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -329,9 +329,9 @@ class MainWP_Auto_Cache_Purge_View {
 			$output_format = 'F j, Y g:ia';
 
 			// Now we can use our timestamp with get_date_from_gmt().
-			$local_timestamp = get_date_from_gmt( $utc_timestamp_converted, $output_format );
+			$local_timestamp = MainWP_Utility::format_timestamp( get_date_from_gmt( $utc_timestamp_converted, $output_format ) );
 
-			// Save local timestamp.
+			// Save local timestamp..
 			$item['mainwp_cache_control_last_purged'] = $local_timestamp;
 		} else {
 			$item['mainwp_cache_control_last_purged'] = 'Never Purged';

--- a/class/class-mainwp-auto-cache-purge-view.php
+++ b/class/class-mainwp-auto-cache-purge-view.php
@@ -323,7 +323,7 @@ class MainWP_Auto_Cache_Purge_View {
             $dt_gmt = gmdate( 'Y-m-d H:i:s', $last_purged );
 
             // Convert GMT into chosen WP DateTime formats.
-            $local_timestamp = date_i18n(get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( get_date_from_gmt( $dt_gmt ) ) );
+            $local_timestamp = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( get_date_from_gmt( $dt_gmt ) ) );
 
             // Save local timestamp..
 			$item['mainwp_cache_control_last_purged'] = $local_timestamp;


### PR DESCRIPTION
Time stamps are saved within MainWP Child DB as UTC. This converts that timestamp into the local timezone set with the MainWP Dashboard. 