### PR TITLE
Added three premium plugins for detection

### DIFF
--- a/class/class-mainwp-premium-update.php
+++ b/class/class-mainwp-premium-update.php
@@ -57,6 +57,7 @@ class MainWP_Premium_Update {
 				'wp-all-import-pro/wp-all-import-pro.php',
 				'bbq-pro/bbq-pro.php',
 				'seedprod-coming-soon-pro-5/seedprod-coming-soon-pro-5.php',
+				'oxygen/functions.php'
 				'elementor-pro/elementor-pro.php',
 				'bbpowerpack/bb-powerpack.php',
 				'bb-ultimate-addon/bb-ultimate-addon.php',
@@ -74,6 +75,8 @@ class MainWP_Premium_Update {
 				'wp-schema-pro/wp-schema-pro.php',
 				'ultimate-elementor/ultimate-elementor.php',
 				'gp-premium/gp-premium.php',
+				'flying-press/flying-press.php',
+				'wp-rocket/wp-rocket.php',
 			);
 
 			/**


### PR DESCRIPTION
Added Oxygen Builder, FlyingPress, and WP Rocket for added detection capabilities as premium plugins. The main reason for adding this was MainWP not recognizing a recent Oxygen Builder version update (4.0) which led me to https://kb.mainwp.com/docs/premium-plugin-updates-not-detected/ which led me to searching that code in GitHub and that's where I found the list of premium plugins, so decided it may help others if included in the source of MainWP for premium plugins so nobody needs to add their own snippets each time.

### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added three premium plugins for additional compatibility with update checking in MainWP. Added Oxygen Builder, FlyingPress, and WP Rocket.

Closes # .

### How to test the changes in this Pull Request:

1. Install an old version of Oxygen Builder (3.8 for example) and save license key in Oxygen Settings
2. Check for updates
3. Should see Oxygen Builder update in the queue 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Improved detection of premium plugin updates for Oxygen Builder, FlyingPress, and WP Rocket.