### PR TITLE
Fix lengthMenu drop-down on monitoring sites list table

### DIFF
--- a/class/class-mainwp-monitoring-sites-list-table.php
+++ b/class/class-mainwp-monitoring-sites-list-table.php
@@ -702,7 +702,7 @@ class MainWP_Monitoring_Sites_List_Table extends MainWP_Manage_Sites_List_Table 
 							},
 							<?php do_action( 'mainwp_manage_sites_table_columns_defs' ); ?>
 						],
-						"lengthMenu" : [ [<?php echo intval( $pagelength_val ); ?>, -1 ], [<?php echo esc_js( $pagelength_title ); ?>, "All" ] ],
+						"lengthMenu" : [ [<?php echo esc_js( $pagelength_val ); ?>, -1 ], [<?php echo esc_js( $pagelength_title ); ?>, "All" ] ],
 						"pageLength": <?php echo intval( $sites_per_page ); ?>
 					} );
 				} catch(err) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

### Explanation

This is only fixing a copy pasta mistake that is in the master branch, causing the length drop-down on Monitoring page to only display then length drop-down 10 (that currently does 10) and 25 (that currently does all).

"Good" example in master branch:
https://github.com/mainwp/mainwp/blob/e56f849867577026402cf399645b0e1c3fd522fb/class/class-mainwp-manage-sites-list-table.php#L1031

"Copy pasta mistake" example in master branch that this pull-request fixes:
https://github.com/mainwp/mainwp/blob/e56f849867577026402cf399645b0e1c3fd522fb/class/class-mainwp-monitoring-sites-list-table.php#L705
Only changed is intval to esc_js to bring it in line with other tables code.