### PR TITLE
Update class-mainwp-utility.php

### DIFF
--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -580,10 +580,10 @@ class MainWP_Utility {
 	 */
 	public static function remove_http_www_prefix( $pUrl ) {
 		$pUrl = self::remove_http_prefix( $pUrl, true );
-                if(str_starts_with(strtolower($pUrl),'www.')){
-                   return substr($pUrl,4);
-                }
-                return $pUrl;
+		if ( str_starts_with(strtolower($pUrl), 'www.') ) {
+			return substr($pUrl, 4);
+		}
+				return $pUrl;
 	}
 
 	/**

--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -580,7 +580,10 @@ class MainWP_Utility {
 	 */
 	public static function remove_http_www_prefix( $pUrl ) {
 		$pUrl = self::remove_http_prefix( $pUrl, true );
-		return str_replace( 'www.', '', $pUrl );
+                if(str_starts_with(strtolower($pUrl),'www.')){
+                   return substr($pUrl,4);
+                }
+                return $pUrl;
 	}
 
 	/**


### PR DESCRIPTION
some sites that use something like this as a domain:

prefix-www.mydomain.it
or
mywwwstrangedomain.it

in these cases, MainWP always removes the www breaking my domain as follows:

prefix-mydomain.it
or
mystrangedomain.it

### All Submissions:

* [ ] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
