### PR TITLE
Workflow: add action to automaically create a github release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,28 @@
+name: Create Release on Stable Tag
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  add-release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Read version from readme.txt
+      id: read-version
+      run: |
+        VERSION=$(grep -Po 'Stable tag: \K.*' readme.txt)
+        echo "RELEASE_TAG=$VERSION" >> "$GITHUB_OUTPUT"
+      
+
+    - name: Create Release
+      id: create-release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.read-version.outputs.RELEASE_TAG }}
+        generate_release_notes: true


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I've added a GitHub Action, which is reading the stable tag from [`readme.txt`](https://github.com/mainwp/mainwp/blob/master/readme.txt#L10) and set a GitHub Release Tag automatically, if the same tag isn't already existing.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #666 

### How to test the changes in this Pull Request:

1. See in my forked repo, it worked

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [~] Have you written new tests for your changes, as applicable?
* [~] Have you successfully run tests with your changes locally?
