### PR TITLE
Fix: Made strings translatable in class-mainwp-plugins-install-list-table.php file

### DIFF
--- a/class/class-mainwp-plugins-install-list-table.php
+++ b/class/class-mainwp-plugins-install-list-table.php
@@ -519,7 +519,7 @@ class MainWP_Plugins_Install_List_Table extends \WP_List_Table { // phpcs:ignore
                     </div>
                 </div>
                     <div class="extra content">
-                        <a href="<?php echo esc_attr( $details_link ); ?>" class="ui mini button open-plugin-details-modal"><?php echo esc_html( 'Plugin Details' ); ?></a>
+                        <a href="<?php echo esc_attr( $details_link ); ?>" class="ui mini button open-plugin-details-modal"><?php echo esc_html__( 'Plugin Details', 'mainwp' ); ?></a>
                         <div class="ui radio checkbox right floated">
                         <input name="install-plugin" type="radio" id="install-plugin-<?php echo sanitize_html_class( $plugin['slug'] ); ?>" plugin-name="<?php echo esc_attr( $title ); ?>" plugin-version="<?php echo esc_attr( $version ); ?>">
                         <label><?php esc_html_e( 'Install Plugin', 'mainwp' ); ?></label>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix: Made strings translatable in class-mainwp-plugins-install-list-table.php file

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix: Made strings translatable in class-mainwp-plugins-install-list-table.php file