### PR TITLE
Fix: MainWP misreports LibreSSL/3.3.6 as lower than OpenSSL/1.1.0

### DIFF
--- a/pages/page-mainwp-server-information-handler.php
+++ b/pages/page-mainwp-server-information-handler.php
@@ -106,10 +106,26 @@ class MainWP_Server_Information_Handler { // phpcs:ignore Generic.Classes.Openin
     public static function curlssl_compare( $version, $operator ) {
         if ( function_exists( 'curl_version' ) ) {
             $ver = static::get_curl_ssl_version();
-            return version_compare( $ver, $version, $operator );
+            return version_compare( static::extract_version( $ver ), static::extract_version( $version ), $operator );
         }
         return false;
     }
+
+	/**
+	 * Method extract_version()
+	 *
+	 * Function to extract version from string for both OpenSSL and LibreSSL
+	 *
+	 * @param string $version_string Version OpenSSL and LibreSSL.
+	 *
+	 * @return mixed null|string
+	 */
+	public static function extract_version( $version_string ) {
+		if ( preg_match( '/(?:LibreSSL|OpenSSL)[\/ ]([\d.]+)/', $version_string, $matches ) ) {
+			return $matches[1];
+		}
+		return null;
+	}
 
     /**
      * Gets file system method.

--- a/pages/page-mainwp-server-information-handler.php
+++ b/pages/page-mainwp-server-information-handler.php
@@ -111,21 +111,21 @@ class MainWP_Server_Information_Handler { // phpcs:ignore Generic.Classes.Openin
         return false;
     }
 
-	/**
-	 * Method extract_version()
-	 *
-	 * Function to extract version from string for both OpenSSL and LibreSSL
-	 *
-	 * @param string $version_string Version OpenSSL and LibreSSL.
-	 *
-	 * @return mixed null|string
-	 */
-	public static function extract_version( $version_string ) {
-		if ( preg_match( '/(?:LibreSSL|OpenSSL)[\/ ]([\d.]+)/', $version_string, $matches ) ) {
-			return $matches[1];
-		}
-		return null;
-	}
+    /**
+     * Method extract_version()
+     *
+     * Function to extract version from string for both OpenSSL and LibreSSL
+     *
+     * @param string $version_string Version OpenSSL and LibreSSL.
+     *
+     * @return mixed null|string
+     */
+    public static function extract_version( $version_string ) {
+        if ( preg_match( '/(?:LibreSSL|OpenSSL)[\/ ]([\d.]+)/', $version_string, $matches ) ) {
+            return $matches[1];
+        }
+        return null;
+    }
 
     /**
      * Gets file system method.

--- a/pages/page-mainwp-server-information.php
+++ b/pages/page-mainwp-server-information.php
@@ -937,7 +937,13 @@ class MainWP_Server_Information { // phpcs:ignore Generic.Classes.OpeningBraceSa
                 static::render_row_with_description( esc_html__( 'PHP Version', 'mainwp' ), '>=', '7.4', 'get_php_version', '', '', null );
                 static::render_row_with_description( esc_html__( 'SSL Extension Enabled', 'mainwp' ), '=', true, 'get_ssl_support', '', '', null );
                 static::render_row_with_description( esc_html__( 'cURL Extension Enabled', 'mainwp' ), '=', true, 'get_curl_support', '', '', null );
-                $openssl_version = 'OpenSSL/1.1.0';
+
+                $ssl_version     = OPENSSL_VERSION_TEXT;
+				$openssl_version = 'OpenSSL/1.1.0';
+				if ( false !== strpos( $ssl_version, 'LibreSSL' ) ) {
+					$openssl_version = 'LibreSSL/2.5.0';
+				}
+
                 static::render_row_with_description(
                     'cURL SSL Version',
                     '>=',
@@ -950,7 +956,20 @@ class MainWP_Server_Information { // phpcs:ignore Generic.Classes.OpeningBraceSa
                 );
 
                 if ( ! MainWP_Server_Information_Handler::curlssl_compare( $openssl_version, '>=' ) ) {
-                    echo "<tr class='warning'><td colspan='4'><i class='attention icon'></i>" . sprintf( esc_html__( 'Your host needs to update OpenSSL to at least version 1.1.0 which is already over 4 years old and contains patches for over 60 vulnerabilities.%1$sThese range from Denial of Service to Remote Code Execution. %2$sClick here for more information.%3$s', 'mainwp' ), '<br/>', '<a href="https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816" target="_blank">', '</a>' ) . '</td></tr>';
+                    ?>
+						<tr class='warning'>
+							<td colspan='4'>
+								<i class='attention icon'></i>
+								<?php
+                                if ( false !== strpos( $ssl_version, 'LibreSSL' ) ) {
+                                    printf( esc_html__( 'Your host needs to update LibreSSL to at least version 2.5.0 which is already over 4 years old and contains patches for over 60 vulnerabilities.%1$sThese range from Denial of Service to Remote Code Execution. %2$sClick here for more information.%3$s', 'mainwp' ), '<br/>', '<a href="https://www.libressl.org/" target="_blank">', '</a>' );
+                                } else {
+                                    printf( esc_html__( 'Your host needs to update OpenSSL to at least version 1.1.0 which is already over 4 years old and contains patches for over 60 vulnerabilities.%1$sThese range from Denial of Service to Remote Code Execution. %2$sClick here for more information.%3$s', 'mainwp' ), '<br/>', '<a href="https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816" target="_blank">', '</a>' );
+                                }
+								?>
+							</td>
+						</tr>
+					<?php
                 }
                 static::render_row_with_description( esc_html__( 'MySQL Version', 'mainwp' ), '>=', '5.0', 'get_mysql_version', '', '', null );
                 ?>

--- a/pages/page-mainwp-server-information.php
+++ b/pages/page-mainwp-server-information.php
@@ -939,10 +939,10 @@ class MainWP_Server_Information { // phpcs:ignore Generic.Classes.OpeningBraceSa
                 static::render_row_with_description( esc_html__( 'cURL Extension Enabled', 'mainwp' ), '=', true, 'get_curl_support', '', '', null );
 
                 $ssl_version     = OPENSSL_VERSION_TEXT;
-				$openssl_version = 'OpenSSL/1.1.0';
-				if ( false !== strpos( $ssl_version, 'LibreSSL' ) ) {
-					$openssl_version = 'LibreSSL/2.5.0';
-				}
+                $openssl_version = 'OpenSSL/1.1.0';
+                if ( false !== strpos( $ssl_version, 'LibreSSL' ) ) {
+                    $openssl_version = 'LibreSSL/2.5.0';
+                }
 
                 static::render_row_with_description(
                     'cURL SSL Version',
@@ -957,19 +957,19 @@ class MainWP_Server_Information { // phpcs:ignore Generic.Classes.OpeningBraceSa
 
                 if ( ! MainWP_Server_Information_Handler::curlssl_compare( $openssl_version, '>=' ) ) {
                     ?>
-						<tr class='warning'>
-							<td colspan='4'>
-								<i class='attention icon'></i>
-								<?php
+                        <tr class='warning'>
+                            <td colspan='4'>
+                                <i class='attention icon'></i>
+                                <?php
                                 if ( false !== strpos( $ssl_version, 'LibreSSL' ) ) {
                                     printf( esc_html__( 'Your host needs to update LibreSSL to at least version 2.5.0 which is already over 4 years old and contains patches for over 60 vulnerabilities.%1$sThese range from Denial of Service to Remote Code Execution. %2$sClick here for more information.%3$s', 'mainwp' ), '<br/>', '<a href="https://www.libressl.org/" target="_blank">', '</a>' );
                                 } else {
                                     printf( esc_html__( 'Your host needs to update OpenSSL to at least version 1.1.0 which is already over 4 years old and contains patches for over 60 vulnerabilities.%1$sThese range from Denial of Service to Remote Code Execution. %2$sClick here for more information.%3$s', 'mainwp' ), '<br/>', '<a href="https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816" target="_blank">', '</a>' );
                                 }
-								?>
-							</td>
-						</tr>
-					<?php
+                                ?>
+                            </td>
+                        </tr>
+                    <?php
                 }
                 static::render_row_with_description( esc_html__( 'MySQL Version', 'mainwp' ), '>=', '5.0', 'get_mysql_version', '', '', null );
                 ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix LibreSSL version check error