### PR TITLE
Fix missing folder creation on file upload via MainWP_QQ2_Uploaded_Fi…

### DIFF
--- a/class/class-mainwp-qq2-uploaded-file-form.php
+++ b/class/class-mainwp-qq2-uploaded-file-form.php
@@ -44,7 +44,7 @@ class MainWP_QQ2_Uploaded_File_Form { // phpcs:ignore Generic.Classes.OpeningBra
         if ( ! is_dir( dirname( $path ) ) ) {
             mkdir( dirname( $path ), 0777, true );
         }
-        
+
         if ( ! empty( $tmp_name ) ) {
             if ( $wpFileSystem ) { //phpcs:ignore -- to valid.
                 $moved = $wp_filesystem->put_contents( $path, $wp_filesystem->get_contents( $tmp_name ) );

--- a/class/class-mainwp-qq2-uploaded-file-form.php
+++ b/class/class-mainwp-qq2-uploaded-file-form.php
@@ -40,6 +40,11 @@ class MainWP_QQ2_Uploaded_File_Form { // phpcs:ignore Generic.Classes.OpeningBra
 
         $tmp_name = isset( $_FILES['qqfile']['tmp_name'] ) && MainWP_Utility::valid_file_check( $_FILES['qqfile']['tmp_name'] ) ? $_FILES['qqfile']['tmp_name'] : ''; //phpcs:ignore -- valid.
 
+        //phpcs:disable WordPress.WP.AlternativeFunctions -- custom process.
+        if ( ! is_dir( dirname( $path ) ) ) {
+            mkdir( dirname( $path ), 0777, true );
+        }
+        
         if ( ! empty( $tmp_name ) ) {
             if ( $wpFileSystem ) { //phpcs:ignore -- to valid.
                 $moved = $wp_filesystem->put_contents( $path, $wp_filesystem->get_contents( $tmp_name ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For context, one can see the conversation starting on Discord here https://discord.com/channels/1153750602086621194/1153750602086621197/1308520448627179532

Fix the save($path) method in MainWP_QQ2_Uploaded_File_Form so that the proper directory within uploads is created on file upload if needed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Delete folder wp-contents/uploads/mainwp/0 if it exists (it does not exist on a fresh install)
2. Try uploading a small plugin (smaller than chunk size so it's not splitted) via the PluginsInstall form
3. Fails w/out patch. Uploads correctly with patch

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
