### PR TITLE
Fixed: URL to check REST API

### DIFF
--- a/pages/page-mainwp-rest-api-page.php
+++ b/pages/page-mainwp-rest-api-page.php
@@ -1208,7 +1208,7 @@ class MainWP_Rest_Api_Page { // phpcs:ignore Generic.Classes.OpeningBraceSameLin
             $args['cookies'] = $cookies;
         }
 
-        $site_url = get_option( 'siteurl' );
+        $site_url = get_option( 'home' );
         $response = wp_remote_post( $site_url . '/wp-json', $args );
         $body     = wp_remote_retrieve_body( $response );
         $data     = is_string( $body ) ? json_decode( $body, true ) : false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

You should use `get_option( 'home' );` instead of `get_option( 'siteurl' );` since when you customize the wordpress url it does not generate an error.

When customizing the WordPress directory the URL to the REST API is: https://site.com/directory-wp/wp-json when the correct one should still be https://site.com/wp-json

### How to test the changes in this Pull Request:

1. Install a blank WordPress site.
2. Change the WordPress installation directory. (https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory)
3. Enter the REST API section in MainWP and this notice will appear.
![REST_API_‹_WP_Manage_—_WordPress_y_7_páginas_más_-_22-11-2024_9PB5C](https://github.com/user-attachments/assets/59dbde47-3185-432c-9b3b-545324176c9e)
 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
