### PR TITLE
fix: selecting by Tag does not select sites on translations Updates page

### DIFF
--- a/pages/page-mainwp-updates-per-group.php
+++ b/pages/page-mainwp-updates-per-group.php
@@ -871,9 +871,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                         <td class="accordion-trigger"><i class="dropdown icon"></i></td>
                         <td>
                             <div class="ui main-master checkbox">
-                                <input type="checkbox" name="">
+                                <input type="checkbox" name="" data-group-id="<?php echo esc_attr( $group_id ); ?>">
+								<label for=""> <?php echo esc_html( stripslashes( $group_name ) ); ?></label>
                             </div>
-                            <?php echo esc_html( stripslashes( $group_name ) ); ?>
                         </td>
                         <td total-uid="uid_translation_updates_<?php echo esc_attr( $group_id ); ?>" sort-value="0"></td>
                         <td class="right aligned">
@@ -884,7 +884,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                         <?php } ?>
                         </td>
                     </tr>
-                    <tr class="content" class="main-child-checkbox">
+                    <tr class="content main-child-checkbox">
                         <td colspan="4">
                             <table class="ui grey table mainwp-per-group-table mainwp-manage-updates-table" id="mainwp-translations-sites-table">
                                 <thead class="mainwp-768-hide">

--- a/pages/page-mainwp-updates-per-group.php
+++ b/pages/page-mainwp-updates-per-group.php
@@ -872,7 +872,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                         <td>
                             <div class="ui main-master checkbox">
                                 <input type="checkbox" name="" data-group-id="<?php echo esc_attr( $group_id ); ?>">
-								<label for=""> <?php echo esc_html( stripslashes( $group_name ) ); ?></label>
+                                <label for=""> <?php echo esc_html( stripslashes( $group_name ) ); ?></label>
                             </div>
                         </td>
                         <td total-uid="uid_translation_updates_<?php echo esc_attr( $group_id ); ?>" sort-value="0"></td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. MainWP -> Dashboard -> Updates -> Translations -> Switch updates per tag

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix the issue with the checkbox not working.