### PR TITLE
Fixed: typo in site health information label

### DIFF
--- a/pages/page-mainwp-settings.php
+++ b/pages/page-mainwp-settings.php
@@ -1920,7 +1920,7 @@ class MainWP_Settings { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Con
             'users'                   => __( 'Users information', 'mainwp' ),
             'plugins_outdate_info'    => __( 'Abandoned plugins information', 'mainwp' ),
             'themes_outdate_info'     => __( 'Abandoned themes information', 'mainwp' ),
-            'health_site_status'      => __( 'Site healt information', 'mainwp' ),
+            'health_site_status'      => __( 'Site health information', 'mainwp' ),
             'child_site_actions_data' => __( 'Non-MainWP changes data', 'mainwp' ),
             'othersData'              => __( 'Other data (required by some extensions)', 'mainwp' ),
         );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Corrects "healt" typo in settings page.

### Changelog entry

> Fixed: Typo in Site health information label on settings page.
