### PR TITLE
Fixed: Incorrect flag display

### DIFF
--- a/class/class-mainwp-system-handler.php
+++ b/class/class-mainwp-system-handler.php
@@ -70,7 +70,7 @@ class MainWP_System_Handler { // phpcs:ignore Generic.Classes.OpeningBraceSameLi
         add_filter( 'mainwp-getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 5 ); // @deprecated Use 'mainwp_getdbsites' instead.
 
         add_filter( 'mainwp_getsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_sites' ), 10, 5 );
-        add_filter( 'mainwp_getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 5 );
+        add_filter( 'mainwp_getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 6 );
         add_filter( 'mainwp_get_db_websites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_websites' ), 10, 5 );
 
         /**

--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -1810,10 +1810,10 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
         $last_two_chars = ! empty( $flag_language ) ? substr( $flag_language, -2 ) : '';
         // Convert to lowercase.
         $lowercase_last_two_chars = strtolower( $last_two_chars );
-    
+
         // Get display name using the original language string.
         $display_language = function_exists( 'locale_get_display_name' ) ? locale_get_display_name( $language ) : $language;
-    
+
         // Adjust special country codes.
         if ( 'et' === $lowercase_last_two_chars ) {
             $lowercase_last_two_chars = 'ee';
@@ -1824,7 +1824,7 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
         if ( 'ab' === $lowercase_last_two_chars ) {
             $lowercase_last_two_chars = 'dz';
         }
-    
+
         echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted=""><i class="small ' . esc_attr( $lowercase_last_two_chars ) . ' flag"></i></span>';
     }
 

--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -1804,15 +1804,17 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
      * @return void
      */
     public static function get_language_code_as_flag( $language ) {
-        // Get the last 2 characters of the language code.
-        $last_two_chars = ! empty( $language ) ? substr( $language, -2 ) : '';
+        // For flag extraction, remove trailing _formal or _informal if present.
+        $flag_language = preg_replace( '/_(formal|informal)$/', '', $language );
+        // Get the last 2 characters of the flag language code.
+        $last_two_chars = ! empty( $flag_language ) ? substr( $flag_language, -2 ) : '';
         // Convert to lowercase.
         $lowercase_last_two_chars = strtolower( $last_two_chars );
-
-        if ( function_exists( 'locale_get_display_name' ) ) {
-            $language = locale_get_display_name( $language );
-        }
-
+    
+        // Get display name using the original language string.
+        $display_language = function_exists( 'locale_get_display_name' ) ? locale_get_display_name( $language ) : $language;
+    
+        // Adjust special country codes.
         if ( 'et' === $lowercase_last_two_chars ) {
             $lowercase_last_two_chars = 'ee';
         }
@@ -1822,8 +1824,8 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
         if ( 'ab' === $lowercase_last_two_chars ) {
             $lowercase_last_two_chars = 'dz';
         }
-
-        echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $language ) . '" data-position="left center" data-inverted=""><i class="small ' . esc_attr( $lowercase_last_two_chars ) . ' flag"></i></span>';
+    
+        echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted=""><i class="small ' . esc_attr( $lowercase_last_two_chars ) . ' flag"></i></span>';
     }
 
     /**

--- a/pages/page-mainwp-extensions-handler.php
+++ b/pages/page-mainwp-extensions-handler.php
@@ -698,16 +698,17 @@ class MainWP_Extensions_Handler { // phpcs:ignore Generic.Classes.OpeningBraceSa
      * @uses  \MainWP\Dashboard\MainWP_Utility::ctype_digit()
      * @uses  \MainWP\Dashboard\MainWP_Utility::map_site()
      */
-    public static function hook_get_db_sites( $pluginFile, $key, $sites, $groups = '', $options = false ) {
+    public static function hook_get_db_sites( $pluginFile, $key, $sites, $groups = '', $options = false, $clients = '' ) {
         if ( ! static::hook_verify( $pluginFile, $key ) ) {
             return false;
         }
 
         MainWP_Deprecated_Hooks::maybe_handle_deprecated_hook();
         $params = array(
-            'fields' => $options,
-            'sites'  => $sites,
-            'groups' => $groups,
+            'fields'  => $options,
+            'sites'   => $sites,
+            'groups'  => $groups,
+            'clients' => $clients,
         );
         return MainWP_DB::instance()->get_db_sites( $params );
     }


### PR DESCRIPTION
For flag extraction, remove trailing _formal or _informal if present.

### All Submissions:

* [x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced language flag display with improved tooltip accuracy for clearer language representation.
- **Refactor**
	- Updated internal data handling to support additional parameters, ensuring smoother integration and processing of site-related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->