### PR TITLE
Phuochoit/mwp 364 site manage menu cannot scroll

### DIFF
--- a/assets/css/mainwp.css
+++ b/assets/css/mainwp.css
@@ -205,6 +205,7 @@ table.mainwp-manage-updates-table tbody tr td .mainwp-update-selected-button {
     box-shadow: 20px 0px 15px -18px rgba(0, 0, 0, 0.15) inset;
     -webkit-box-shadow: 20px 0px 15px -18px rgba(0, 0, 0, 0.15) inset;
 	overflow-y: auto;
+	overflow-x: hidden;
 }
 
 .mainwp-individual-site-view #mainwp-page-navigation-wrapper .mainwp-page-navigation {

--- a/assets/css/mainwp.css
+++ b/assets/css/mainwp.css
@@ -204,6 +204,7 @@ table.mainwp-manage-updates-table tbody tr td .mainwp-update-selected-button {
     width: 200px;
     box-shadow: 20px 0px 15px -18px rgba(0, 0, 0, 0.15) inset;
     -webkit-box-shadow: 20px 0px 15px -18px rgba(0, 0, 0, 0.15) inset;
+	overflow-y: auto;
 }
 
 .mainwp-individual-site-view #mainwp-page-navigation-wrapper .mainwp-page-navigation {


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [MainWP Contributing guideline](https://github.com/mainwp/mainwp/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/mainwp/mainwp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Goto managesites Page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix error site menu managesites not scroll