### PR TITLE
Added: `$clients` parameter to the `mainwp_getdbsites` filter

### DIFF
--- a/class/class-mainwp-system-handler.php
+++ b/class/class-mainwp-system-handler.php
@@ -67,10 +67,10 @@ class MainWP_System_Handler { // phpcs:ignore Generic.Classes.OpeningBraceSameLi
          * @see \MainWP_Extensions::hook_get_sites
          */
         add_filter( 'mainwp-getsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_sites' ), 10, 5 );     // @deprecated Use 'mainwp_getsites' instead.
-        add_filter( 'mainwp-getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 5 ); // @deprecated Use 'mainwp_getdbsites' instead.
+        add_filter( 'mainwp-getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 6 ); // @deprecated Use 'mainwp_getdbsites' instead.
 
         add_filter( 'mainwp_getsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_sites' ), 10, 5 );
-        add_filter( 'mainwp_getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 5 );
+        add_filter( 'mainwp_getdbsites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_sites' ), 10, 6 );
         add_filter( 'mainwp_get_db_websites', array( MainWP_Extensions_Handler::get_class_name(), 'hook_get_db_websites' ), 10, 5 );
 
         /**

--- a/class/class-mainwp-ui.php
+++ b/class/class-mainwp-ui.php
@@ -198,7 +198,7 @@ class MainWP_UI { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.ContentAf
         ?>
         <div id="mainwp-select-sites-filters">
             <div class="ui mini fluid icon input">
-                <input type="text" id="mainwp-select-sites-filter" value="" placeholder="<?php esc_attr_e( 'Type to filter your sites', 'mainwp' ); ?>" <?php echo 'site' === $selectedby ? '' : 'style="display: none;"'; ?> />
+                <input type="text" id="mainwp-select-sites-filter" value="" placeholder="<?php esc_attr_e( 'Type to filter your sites', 'mainwp' ); ?>" />
                 <i class="filter icon"></i>
             </div>
         </div>

--- a/pages/page-mainwp-extensions-handler.php
+++ b/pages/page-mainwp-extensions-handler.php
@@ -699,28 +699,27 @@ class MainWP_Extensions_Handler { // phpcs:ignore Generic.Classes.OpeningBraceSa
         }
     }
 
-     /**
-      * Retrieves database sites based on provided parameters.
-      *
-      * This method verifies the hook using the plugin file and key, then retrieves
-      * sites from the database according to the specified criteria.
-      *
-      *
-      * @param string       $pluginFile The path to the plugin file for verification.
-      * @param string       $key        The key used for hook verification.
-      * @param array|string $sites      Site IDs to retrieve. Can be an array of IDs or a comma-separated string.
-      * @param array|string $groups     Optional. Group IDs to filter sites by. Can be an array or comma-separated string.
-      *                                 Default is empty string.
-      * @param array|bool   $options    Optional. Fields to return or additional query options.
-      *                                 Set to false to return all fields. Default is false.
-      * @param array|string $clients    Optional. Client IDs to filter sites by. Can be an array or comma-separated string.
-      *                                 Default is empty string.
-      *
-      * @return array|bool  Array of site objects on success, or false if hook verification fails.
-      *
-      * @uses \MainWP\Dashboard\MainWP_Utility::ctype_digit()
-      * @uses \MainWP\Dashboard\MainWP_Utility::map_site()
-      */
+    /**
+     * Retrieves database sites based on provided parameters.
+     *
+     * This method verifies the hook using the plugin file and key, then retrieves
+     * sites from the database according to the specified criteria.
+     *
+     * @param string       $pluginFile The path to the plugin file for verification.
+     * @param string       $key        The key used for hook verification.
+     * @param array|string $sites      Site IDs to retrieve. Can be an array of IDs or a comma-separated string.
+     * @param array|string $groups     Optional. Group IDs to filter sites by. Can be an array or comma-separated string.
+     *                                 Default is empty string.
+     * @param array|bool   $options    Optional. Fields to return or additional query options.
+     *                                 Set to false to return all fields. Default is false.
+     * @param array|string $clients    Optional. Client IDs to filter sites by. Can be an array or comma-separated string.
+     *                                 Default is empty string.
+     *
+     * @return array|bool  Array of site objects on success, or false if hook verification fails.
+     *
+     * @uses \MainWP\Dashboard\MainWP_Utility::ctype_digit()
+     * @uses \MainWP\Dashboard\MainWP_Utility::map_site()
+     */
     public static function hook_get_db_sites( $pluginFile, $key, $sites, $groups = '', $options = false, $clients = '' ) {
         if ( ! static::hook_verify( $pluginFile, $key ) ) {
             return false;

--- a/pages/page-mainwp-extensions-handler.php
+++ b/pages/page-mainwp-extensions-handler.php
@@ -713,16 +713,17 @@ class MainWP_Extensions_Handler { // phpcs:ignore Generic.Classes.OpeningBraceSa
      * @uses  \MainWP\Dashboard\MainWP_Utility::ctype_digit()
      * @uses  \MainWP\Dashboard\MainWP_Utility::map_site()
      */
-    public static function hook_get_db_sites( $pluginFile, $key, $sites, $groups = '', $options = false ) {
+    public static function hook_get_db_sites( $pluginFile, $key, $sites, $groups = '', $options = false, $clients = '' ) {
         if ( ! static::hook_verify( $pluginFile, $key ) ) {
             return false;
         }
 
         MainWP_Deprecated_Hooks::maybe_handle_deprecated_hook();
         $params = array(
-            'fields' => $options,
-            'sites'  => $sites,
-            'groups' => $groups,
+            'fields'  => $options,
+            'sites'   => $sites,
+            'groups'  => $groups,
+            'clients' => $clients,
         );
         return MainWP_DB::instance()->get_db_sites( $params );
     }

--- a/pages/page-mainwp-extensions-handler.php
+++ b/pages/page-mainwp-extensions-handler.php
@@ -699,20 +699,28 @@ class MainWP_Extensions_Handler { // phpcs:ignore Generic.Classes.OpeningBraceSa
         }
     }
 
-    /**
-     * Get DB Sites.
-     *
-     * @param mixed  $pluginFile Extension plugin file to verify.
-     * @param mixed  $key The child-key.
-     * @param mixed  $sites Child Sites.
-     * @param string $groups Groups.
-     * @param bool   $options Options.
-     *
-     * @return array $dbwebsites.
-     *
-     * @uses  \MainWP\Dashboard\MainWP_Utility::ctype_digit()
-     * @uses  \MainWP\Dashboard\MainWP_Utility::map_site()
-     */
+     /**
+      * Retrieves database sites based on provided parameters.
+      *
+      * This method verifies the hook using the plugin file and key, then retrieves
+      * sites from the database according to the specified criteria.
+      *
+      *
+      * @param string       $pluginFile The path to the plugin file for verification.
+      * @param string       $key        The key used for hook verification.
+      * @param array|string $sites      Site IDs to retrieve. Can be an array of IDs or a comma-separated string.
+      * @param array|string $groups     Optional. Group IDs to filter sites by. Can be an array or comma-separated string.
+      *                                 Default is empty string.
+      * @param array|bool   $options    Optional. Fields to return or additional query options.
+      *                                 Set to false to return all fields. Default is false.
+      * @param array|string $clients    Optional. Client IDs to filter sites by. Can be an array or comma-separated string.
+      *                                 Default is empty string.
+      *
+      * @return array|bool  Array of site objects on success, or false if hook verification fails.
+      *
+      * @uses \MainWP\Dashboard\MainWP_Utility::ctype_digit()
+      * @uses \MainWP\Dashboard\MainWP_Utility::map_site()
+      */
     public static function hook_get_db_sites( $pluginFile, $key, $sites, $groups = '', $options = false, $clients = '' ) {
         if ( ! static::hook_verify( $pluginFile, $key ) ) {
             return false;


### PR DESCRIPTION
Added the `$clients`, as the 6th parameter to the `mainwp_getdbsites` filter to extensions can get sites info by clilents selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the site information retrieval process by supporting an additional input parameter, improving flexibility in site management and integration while maintaining existing functionality.
	- Input field for filtering sites is now always visible, enhancing user interface accessibility.
- **Documentation**
	- Updated documentation for the site retrieval method to clarify parameter descriptions and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->