### PR TITLE
Mainwp dev 5.4.0.7 hotfix

### DIFF
--- a/assets/js/mainwp.js
+++ b/assets/js/mainwp.js
@@ -3767,6 +3767,13 @@ let mainwp_sites_changes_actions_bulk_action = function (act, which_act) {
     let selector = '#mainwp-module-log-records-body-table tr';
     mainwpVars.bulkInstallTotal = jQuery(selector).find('input[type="checkbox"]:checked').length;
     jQuery(selector).addClass('queue');
+    if (jQuery(selector).length) {
+        if(mainwpVars.bulkActionIndent === 'widget'){
+            jQuery('#mainwp_widget_sites_changes_bulk_dismiss_selected_btn').addClass('disabled');
+        } else {
+            jQuery('#mainwp_sites_changes_bulk_dismiss_selected_btn').addClass('disabled');
+        }
+    }
     mainwp_sites_changes_actions_dismiss_start_next(selector);
   } else if( act === 'dismiss-all' ) {
     jQuery('#mainwp_sites_changes_bulk_dismiss_all_btn').addClass('disabled');
@@ -3782,14 +3789,6 @@ let mainwp_sites_changes_actions_dismiss_start_next = function (selector) {
     }
     mainwp_sites_changes_actions_dismiss_specific(objProcess, selector);
   }
-
-    if (mainwpVars.bulkInstallTotal == bulkInstallDone) {
-        if(mainwpVars.bulkActionIndent === 'widget'){
-            jQuery('#mainwp_widget_sites_changes_bulk_dismiss_selected_btn').removeClass('disabled');
-        } else {
-            jQuery('#mainwp_sites_changes_bulk_dismiss_selected_btn').removeClass('disabled');
-        }
-    }
 }
 
 let mainwp_sites_changes_actions_dismiss_specific = function (pObj, selector) {

--- a/assets/js/mainwp.js
+++ b/assets/js/mainwp.js
@@ -3754,10 +3754,14 @@ let mainwp_insights_row_actions_dismiss = function (obj) {
 
 
 // Manage Bulk Actions
-let mainwp_sites_changes_actions_bulk_action = function (act) {
+let mainwp_sites_changes_actions_bulk_action = function (act, which_act) {
   mainwpVars.bulkInstallTotal = 0;
   bulkInstallCurrentThreads = 0;
   bulkInstallDone = 0;
+  mainwpVars.bulkActionIndent = '';
+  if(which_act === 'widget'){
+    mainwpVars.bulkActionIndent = 'widget';
+  }
   if ( act === 'dismiss-selected' ) {
     jQuery('#mainwp_sites_changes_bulk_dismiss_selected_btn').addClass('disabled');
     let selector = '#mainwp-module-log-records-body-table tr';
@@ -3778,6 +3782,14 @@ let mainwp_sites_changes_actions_dismiss_start_next = function (selector) {
     }
     mainwp_sites_changes_actions_dismiss_specific(objProcess, selector);
   }
+
+    if (mainwpVars.bulkInstallTotal == bulkInstallDone) {
+        if(mainwpVars.bulkActionIndent === 'widget'){
+            jQuery('#mainwp_widget_sites_changes_bulk_dismiss_selected_btn').removeClass('disabled');
+        } else {
+            jQuery('#mainwp_sites_changes_bulk_dismiss_selected_btn').removeClass('disabled');
+        }
+    }
 }
 
 let mainwp_sites_changes_actions_dismiss_specific = function (pObj, selector) {
@@ -3813,9 +3825,6 @@ let mainwp_sites_changes_actions_dismiss_specific = function (pObj, selector) {
     bulkInstallCurrentThreads--;
     bulkInstallDone++;
     mainwp_sites_changes_actions_dismiss_start_next(selector);
-    if (mainwpVars.bulkInstallTotal == bulkInstallDone) {
-        jQuery('#mainwp_sites_changes_bulk_dismiss_selected_btn').removeClass('disabled');
-    }
   }, 'json');
   return false;
 }

--- a/class/class-mainwp-manage-sites-update-view.php
+++ b/class/class-mainwp-manage-sites-update-view.php
@@ -109,7 +109,7 @@ class MainWP_Manage_Sites_Update_View { // phpcs:ignore Generic.Classes.OpeningB
             static::render_abandoned_plugins( $website, $active_tab, $userExtension );
             static::render_abandoned_themes( $website, $active_tab, $userExtension );
 
-            // @since 5.4.1.
+            // @since 5.4.0.7 - custom individual update tabs.
             do_action( 'mainwp_individual_updates_tabs', $website, $userExtension );
             ?>
         </div>

--- a/class/class-mainwp-system.php
+++ b/class/class-mainwp-system.php
@@ -29,7 +29,7 @@ class MainWP_System { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Conte
      *
      * @var string Current plugin version.
      */
-    public static $version = '5.4.0.6'; // NOSONAR.
+    public static $version = '5.4.0.7'; // NOSONAR.
 
     /**
      * Private static variable to hold the single instance of the class.

--- a/mainwp.php
+++ b/mainwp.php
@@ -8,7 +8,7 @@
  * Author URI: https://mainwp.com
  * Plugin URI: https://mainwp.com/
  * Text Domain: mainwp
- * Version:  5.4.0.6
+ * Version:  5.4.0.7
  *
  * @package MainWP/Dashboard
  *

--- a/pages/page-mainwp-updates-per-item.php
+++ b/pages/page-mainwp-updates-per-item.php
@@ -795,7 +795,7 @@ class MainWP_Updates_Per_Item { // phpcs:ignore Generic.Classes.OpeningBraceSame
             </tbody>
         </table>
         <?php else : ?>
-            <?php MainWP_UI::render_empty_page_placeholder( __( 'You\'re All Set!', 'mainwp' ), __( 'No abandoned plugins detected.', 'mainwp' ) ); ?>
+            <?php MainWP_UI::render_empty_page_placeholder( __( 'You\'re All Set!', 'mainwp' ), __( 'No abandoned themes detected.', 'mainwp' ) ); ?>
         <?php endif; ?>
         <?php
     }

--- a/pages/page-mainwp-updates.php
+++ b/pages/page-mainwp-updates.php
@@ -591,6 +591,36 @@ class MainWP_Updates { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
                 $total_themes_outdate += count( $themes_outdate );
             }
 
+            // to fix displaying per sites/tags.
+            if ( is_array( $plugins_outdate ) ) {
+                foreach ( $plugins_outdate as $slug => $plugin_outdate ) {
+                    $slug = esc_html( $slug );
+                    if ( ! isset( $allPluginsOutdate[ $slug ] ) ) {
+                        $allPluginsOutdate[ $slug ] = array(
+                            'name' => esc_html( $plugin_outdate['Name'] ),
+                            'cnt'  => 1,
+                            'uri'  => esc_html( $plugin_outdate['PluginURI'] ),
+                        );
+                    } else {
+                        ++$allPluginsOutdate[ $slug ]['cnt'];
+                    }
+                }
+            }
+
+            if ( is_array( $themes_outdate ) ) {
+                foreach ( $themes_outdate as $slug => $theme_outdate ) {
+                    $slug = esc_html( $slug );
+                    if ( ! isset( $allThemesOutdate[ $slug ] ) ) {
+                        $allThemesOutdate[ $slug ] = array(
+                            'name' => esc_html( $theme_outdate['Name'] ),
+                            'cnt'  => 1,
+                        );
+                    } else {
+                        ++$allThemesOutdate[ $slug ]['cnt'];
+                    }
+                }
+            }
+
             if ( MAINWP_VIEW_PER_PLUGIN_THEME === $site_view ) {
                 if ( is_array( $translation_upgrades ) ) {
                     foreach ( $translation_upgrades as $translation_upgrade ) {
@@ -654,35 +684,6 @@ class MainWP_Updates { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
                             'name'    => $up_th_name,
                             'premium' => ( isset( $theme_upgrade['premium'] ) ? esc_html( $theme_upgrade['premium'] ) : 0 ),
                         );
-                    }
-                }
-
-                if ( is_array( $plugins_outdate ) ) {
-                    foreach ( $plugins_outdate as $slug => $plugin_outdate ) {
-                        $slug = esc_html( $slug );
-                        if ( ! isset( $allPluginsOutdate[ $slug ] ) ) {
-                            $allPluginsOutdate[ $slug ] = array(
-                                'name' => esc_html( $plugin_outdate['Name'] ),
-                                'cnt'  => 1,
-                                'uri'  => esc_html( $plugin_outdate['PluginURI'] ),
-                            );
-                        } else {
-                            ++$allPluginsOutdate[ $slug ]['cnt'];
-                        }
-                    }
-                }
-
-                if ( is_array( $themes_outdate ) ) {
-                    foreach ( $themes_outdate as $slug => $theme_outdate ) {
-                        $slug = esc_html( $slug );
-                        if ( ! isset( $allThemesOutdate[ $slug ] ) ) {
-                            $allThemesOutdate[ $slug ] = array(
-                                'name' => esc_html( $theme_outdate['Name'] ),
-                                'cnt'  => 1,
-                            );
-                        } else {
-                            ++$allThemesOutdate[ $slug ]['cnt'];
-                        }
                     }
                 }
             }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,6 +12,7 @@
 	<exclude-pattern>libs/</exclude-pattern>
 	<exclude-pattern>assets/js/apexcharts/*</exclude-pattern>
     <exclude-pattern>assets/js/gridstack/*</exclude-pattern>
+    <exclude-pattern>assets/js/dropzone/*</exclude-pattern>
 	<exclude-pattern>cron/</exclude-pattern>
 
     <arg value="sp" />

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Plugin URI: https://mainwp.com
 Requires at least: 6.2
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 5.4.0.6
+Stable tag: 5.4.0.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -146,6 +146,11 @@ Yes, we have a quick FAQ with many more questions and answers [here](https://mai
 10. Dashboard Insights
 
 == Changelog ==
+
+= 5.4.0.7 - Maintenance Release - 4-29-2025 =
+
+* Fixed: Corrected the display of abandoned plugins and themes to ensure counts and details appear consistently across all views, including per site and per tag views. (#768)[https://github.com/mainwp/mainwp/issues/768]
+* Fixed: Improved bulk dismiss button handling to properly differentiate between widget and non-widget contexts, resulting in more consistent user interaction.
 
 = 5.4.0.6 - Maintenance Release - 4-22-2025 =
 

--- a/widgets/widget-mainwp-site-actions.php
+++ b/widgets/widget-mainwp-site-actions.php
@@ -146,6 +146,13 @@ class MainWP_Site_Actions { // phpcs:ignore Generic.Classes.OpeningBraceSameLine
         <input type="hidden" id="mainwp-widget-filter-events-limit" value="<?php echo isset( $params['limit'] ) ? intval( $params['limit'] ) : 50; ?>" />
 
         <div id="mainwp-widget-site-actions" class="mainwp-scrolly-overflow">
+            <div class="ui stackable grid">
+                <div class="eight wide middle aligned column">
+                    <a href="javascript:void(0)" id="mainwp_widget_sites_changes_bulk_dismiss_selected_btn" class="ui button mini basic"><?php esc_html_e( 'Dismiss Selected Changes', 'mainwp' ); ?></a>
+                </div>
+                <div class="eight wide right aligned middle aligned column">
+                </div>
+            </div>
             <?php
             /**
              * Actoin: mainwp_non_mainwp_changes_widget_top
@@ -190,7 +197,7 @@ class MainWP_Site_Actions { // phpcs:ignore Generic.Classes.OpeningBraceSameLine
                     ?>
                 </div>
         </div>
-        
+
         <div class="mainwp-widget-footer">
             <div class="ui two columns stackable grid">
                 <div class="left aligned middle aligned column">

--- a/widgets/widget-mainwp-site-actions.php
+++ b/widgets/widget-mainwp-site-actions.php
@@ -146,13 +146,6 @@ class MainWP_Site_Actions { // phpcs:ignore Generic.Classes.OpeningBraceSameLine
         <input type="hidden" id="mainwp-widget-filter-events-limit" value="<?php echo isset( $params['limit'] ) ? intval( $params['limit'] ) : 50; ?>" />
 
         <div id="mainwp-widget-site-actions" class="mainwp-scrolly-overflow">
-            <div class="ui stackable grid">
-                <div class="eight wide middle aligned column">
-                    <a href="javascript:void(0)" id="mainwp_widget_sites_changes_bulk_dismiss_selected_btn" class="ui button mini basic"><?php esc_html_e( 'Dismiss Selected Changes', 'mainwp' ); ?></a>
-                </div>
-                <div class="eight wide right aligned middle aligned column">
-                </div>
-            </div>
             <?php
             /**
              * Actoin: mainwp_non_mainwp_changes_widget_top


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the placeholder message to accurately state "No abandoned themes detected" when no abandoned themes are found.
	- Fixed the display of outdated plugins and themes so that counts and details are shown correctly across all views, including per site and per tag.
- **Improvements**
	- Enhanced bulk dismiss action handling to differentiate between widget and non-widget contexts, improving user interaction consistency.
- **Chores**
	- Updated code quality configuration to exclude specific JavaScript library files from linting.
	- Minor UI cleanup by removing unnecessary whitespace in site actions widget.
	- Updated plugin version to 5.4.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->