### PR TITLE
Mainwp dev 5.4.0.8

### DIFF
--- a/assets/css/themes/mainwp-dark-theme.css
+++ b/assets/css/themes/mainwp-dark-theme.css
@@ -391,12 +391,15 @@ body.mainwp-ui.mainwp-custom-theme,
   background: var(--background-color-3) !important;
 }
 
+.mainwp-ui.mainwp-custom-theme #mainwp-db-plugins-updates-table tr.active table tfoot tr th,
+.mainwp-ui.mainwp-custom-theme #mainwp-db-plugins-updates-table tr.active table thead tr th,
 .mainwp-ui.mainwp-custom-theme #mainwp-manage-updates table tr.content.active table tfoot tr th,
 .mainwp-ui.mainwp-custom-theme #mainwp-manage-updates table tr.content.active table thead tr th {
   background: var(--background-color-2) !important;
   color: var(--font-color) !important;
 }
 
+.mainwp-ui.mainwp-custom-theme #mainwp-db-plugins-updates-table tr.active table tbody tr td,
 .mainwp-ui.mainwp-custom-theme #mainwp-manage-updates table tr.content.active table tbody tr td {
   background: var(--background-color-2) !important;
   color: var(--font-color) !important;

--- a/assets/js/mainwp-updates.js
+++ b/assets/js/mainwp-updates.js
@@ -593,12 +593,15 @@ let updatesoverview_translations_upgrade_int = function (slug, websiteId, bulkMo
                     let slugParts = pSlug.split(',');
                     let done = false;
                     for (let sid of slugParts) {
+                        let _error = '';
                         let websiteHolder = jQuery('.translations-bulk-updates[translation_slug="' + sid + '"] tr[site_id="' + pWebsiteId + '"]');
                         if (!websiteHolder.exists()) {
                             websiteHolder = jQuery('.translations-bulk-updates[site_id="' + pWebsiteId + '"] tr[translation_slug="' + sid + '"]');
                         }
 
                         if (response.error) {
+                            mainwpVars.errorCount++;
+                            _error = response.error;
                             if (!done && pBulkMode)
                                 updatesoverview_translations_upgrade_all_update_site_status(pWebsiteId, '<i class="red times icon"></i>');
                             websiteHolder.find('td:last-child').html('<i class="red times icon"></i>');
@@ -612,6 +615,8 @@ let updatesoverview_translations_upgrade_int = function (slug, websiteId, bulkMo
                                 websiteHolder.attr('updated', 1);
                                 websiteHolder.find('td:last-child').html(_success_icon);
                             } else {
+                                mainwpVars.errorCount++;
+                                _error = __('Update failed. Please try again.');
                                 if (!done && pBulkMode)
                                     updatesoverview_translations_upgrade_all_update_site_status(pWebsiteId, '<i class="red times icon"></i>');
                                 websiteHolder.find('td:last-child').html('<i class="red times icon"></i>');
@@ -620,6 +625,10 @@ let updatesoverview_translations_upgrade_int = function (slug, websiteId, bulkMo
                         if (!done && pBulkMode) {
                             updatesoverview_translations_upgrade_all_update_done();
                             done = true;
+                        }
+                        if(_error != ''){
+                            updatesoverview_upgrade_all_update_site_status(pWebsiteId, '<span class="mainwp-html-popup" data-position="left center" data-html=""><i class="red times icon"></i></span>');
+                            mainwp_init_html_popup('.updatesoverview-upgrade-status-wp[siteid="' + pWebsiteId + '"] .mainwp-html-popup', _error);
                         }
                     }
                 }

--- a/assets/js/mainwp-updates.js
+++ b/assets/js/mainwp-updates.js
@@ -601,10 +601,11 @@ let updatesoverview_translations_upgrade_int = function (slug, websiteId, bulkMo
 
                         if (response.error) {
                             mainwpVars.errorCount++;
-                            _error = response.error;
+                            _error = getErrorMessageInfo(response.error);
+                            let extErr = getErrorMessageInfo(response.error, 'ui');
                             if (!done && pBulkMode)
-                                updatesoverview_translations_upgrade_all_update_site_status(pWebsiteId, '<i class="red times icon"></i>');
-                            websiteHolder.find('td:last-child').html('<i class="red times icon"></i>');
+                                updatesoverview_translations_upgrade_all_update_site_status(pWebsiteId, extErr);
+                            websiteHolder.find('td:last-child').html(extErr);
                         } else {
                             let res = response.result;
                             let regression_icon = render_html_regression_icon(res);
@@ -617,18 +618,16 @@ let updatesoverview_translations_upgrade_int = function (slug, websiteId, bulkMo
                             } else {
                                 mainwpVars.errorCount++;
                                 _error = __('Update failed. Please try again.');
-                                if (!done && pBulkMode)
-                                    updatesoverview_translations_upgrade_all_update_site_status(pWebsiteId, '<i class="red times icon"></i>');
+                                if (!done && pBulkMode) {
+                                    updatesoverview_translations_upgrade_all_update_site_status(pWebsiteId, '<span class="mainwp-html-popup" data-position="left center" data-html=""><i class="red times icon"></i></span>');
+                                    mainwp_init_html_popup('.updatesoverview-upgrade-status-wp[siteid="' + pWebsiteId + '"] .mainwp-html-popup', _error);
+                                }
                                 websiteHolder.find('td:last-child').html('<i class="red times icon"></i>');
                             }
                         }
                         if (!done && pBulkMode) {
                             updatesoverview_translations_upgrade_all_update_done();
                             done = true;
-                        }
-                        if(_error != ''){
-                            updatesoverview_upgrade_all_update_site_status(pWebsiteId, '<span class="mainwp-html-popup" data-position="left center" data-html=""><i class="red times icon"></i></span>');
-                            mainwp_init_html_popup('.updatesoverview-upgrade-status-wp[siteid="' + pWebsiteId + '"] .mainwp-html-popup', _error);
                         }
                     }
                 }
@@ -2292,7 +2291,7 @@ let updatesoverview_upgrade_int_flow = function (params) { // NOSONAR - complex.
                 _error = otherErrors
             }
 
-            if(_error == ''){
+            if (_error == '') {
                 _error = __('Update failed. Please try again.');
             }
 

--- a/assets/js/mainwp-updates.js
+++ b/assets/js/mainwp-updates.js
@@ -2174,6 +2174,7 @@ let updatesoverview_upgrade_int_flow = function (params) {
             data: data,
             success: function (pWebsiteId, pThemeSlugToUpgrade, pPluginSlugToUpgrade, pWordpressUpgrade, pThemeDone, pUpgradeDone, pErrorMessage, pSlug) { // NOSONAR - compatible.
                 return function (response) { // NOSONAR -complex.
+                    console.log(response);
                     if (response?.error?.errorCode == 'SUSPENDED_SITE') {
                         let msgUI = '<span data-inverted="" data-position="left center" data-tooltip="' + __('Suspended site.') + '"><i class="pause circular yellow inverted icon"></i></span>';
                         updatesoverview_upgrade_all_update_site_bold(pWebsiteId, false, msgUI);
@@ -2281,6 +2282,13 @@ let updatesoverview_upgrade_int_flow = function (params) {
             } else {
                 _error = otherErrors
             }
+
+            if(_error == ''){
+                _error = __('Update failed. Please try again.');
+            }
+
+            console.log('Update error.');
+            console.log(pErrorMessage);
 
             updatesoverview_upgrade_all_update_site_status(pWebsiteId, '<span class="mainwp-html-popup" data-position="left center" data-html="">' + _icon + '</span>');
             mainwp_init_html_popup('.updatesoverview-upgrade-status-wp[siteid="' + pWebsiteId + '"] .mainwp-html-popup', _error);

--- a/assets/js/mainwp-updates.js
+++ b/assets/js/mainwp-updates.js
@@ -1838,7 +1838,7 @@ let updatesoverview_upgrade_all_update_done = function () {
 };
 
 /* eslint-disable complexity */
-let updatesoverview_upgrade_int_flow = function (params) {
+let updatesoverview_upgrade_int_flow = function (params) { // NOSONAR - complex.
     let pWebsiteId = params['pWebsiteId'];
     let pThemeSlugToUpgrade = params['pThemeSlugToUpgrade'];
     let pPluginSlugToUpgrade = params['pPluginSlugToUpgrade'];

--- a/class/class-mainwp-extensions-view.php
+++ b/class/class-mainwp-extensions-view.php
@@ -1595,7 +1595,7 @@ class MainWP_Extensions_View { // phpcs:ignore Generic.Classes.OpeningBraceSameL
             ),
             'mainwp-vulnerability-checker-extension'  =>
             array(
-                'type'                   => 'pro',
+                'type'                   => 'free',
                 'model'                  => 'integration',
                 'slug'                   => 'mainwp-vulnerability-checker-extension',
                 'title'                  => 'MainWP Vulnerability Checker Extension',

--- a/class/class-mainwp-manage-sites-list-table.php
+++ b/class/class-mainwp-manage-sites-list-table.php
@@ -301,6 +301,10 @@ class MainWP_Manage_Sites_List_Table { // phpcs:ignore Generic.Classes.OpeningBr
             unset( $columns['uptime'] );
         }
 
+        if ( ! \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
+            unset( $columns['client_name'] );
+        }
+
         if ( $this->site_health_disabled ) {
             unset( $columns['site_health'] );
         }
@@ -608,6 +612,7 @@ class MainWP_Manage_Sites_List_Table { // phpcs:ignore Generic.Classes.OpeningBr
                         <div class="item" data-value="suspended"><?php esc_html_e( 'Suspended', 'mainwp' ); ?></div>
                     </div>
                 </div>
+                <?php if ( \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) { ?>
                 <div id="mainwp-filter-clients" class="ui selection mini multiple dropdown seg_site_clients">
                     <input type="hidden" value="<?php echo esc_html( $selected_client ); ?>">
                     <i class="dropdown icon"></i>
@@ -624,6 +629,7 @@ class MainWP_Manage_Sites_List_Table { // phpcs:ignore Generic.Classes.OpeningBr
                         <div class="item" data-value="noclients"><?php esc_html_e( 'No Client', 'mainwp' ); ?></div>
                     </div>
                 </div>
+                <?php } ?>
                 <button onclick="mainwp_manage_sites_filter()" class="ui mini green button"><?php esc_html_e( 'Filter Sites', 'mainwp' ); ?></button>
                 <button onclick="mainwp_manage_sites_reset_filters(this)" id="mainwp_manage_sites_reset_filters" class="ui mini button" <?php echo $default_filter ? 'disabled="disabled"' : ''; ?>><?php esc_html_e( 'Reset Filters', 'mainwp' ); ?></button>
             </div>
@@ -1249,7 +1255,7 @@ class MainWP_Manage_Sites_List_Table { // phpcs:ignore Generic.Classes.OpeningBr
                                             action: 'mainwp_manage_sites_display_rows',
                                             status: jQuery("#mainwp-filter-sites-status").dropdown("get value"),
                                             g: jQuery("#mainwp-filter-sites-group").dropdown("get value"),
-                                            client: jQuery("#mainwp-filter-clients").dropdown("get value"),
+                                            client: jQuery("#mainwp-filter-clients").length ? jQuery("#mainwp-filter-clients").dropdown("get value") : '',
                                             isnot: jQuery("#mainwp_is_not_site").dropdown("get value"),
                                         } )
                                     );

--- a/class/class-mainwp-manage-sites-list-table.php
+++ b/class/class-mainwp-manage-sites-list-table.php
@@ -520,7 +520,7 @@ class MainWP_Manage_Sites_List_Table { // phpcs:ignore Generic.Classes.OpeningBr
      *
      * @uses \MainWP\Dashboard\MainWP_DB_Common::instance()::get_groups_for_manage_sites()
      */
-    public function render_manage_sites_table_top() { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.ContentAfterBrace -- NOSONAR - complexity.
+    public function render_manage_sites_table_top() { // phpcs:ignore -- NOSONAR - complexity.
         $items_bulk        = $this->get_bulk_actions();
         $filters_row_style = 'display:none';
 

--- a/class/class-mainwp-manage-sites-view.php
+++ b/class/class-mainwp-manage-sites-view.php
@@ -1077,8 +1077,9 @@ class MainWP_Manage_Sites_View { // phpcs:ignore Generic.Classes.OpeningBraceSam
                     </div>
                 </div>
                 <?php
-                $clients = MainWP_DB_Client::instance()->get_wp_client_by( 'all' );
-                ?>
+                if ( \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
+                    $clients = MainWP_DB_Client::instance()->get_wp_client_by( 'all' );
+                    ?>
                 <div class="ui grid field settings-field-indicator-wrapper settings-field-indicator-edit-site-general">
                     <label class="six wide column middle aligned">
                     <?php
@@ -1107,6 +1108,7 @@ class MainWP_Manage_Sites_View { // phpcs:ignore Generic.Classes.OpeningBraceSam
                         <a href="javascript:void(0)" class="ui basic green button edit-site-new-client-button"><?php esc_html_e( 'Create New Client', 'mainwp' ); ?></a>
                     </div>
                 </div>
+                <?php } ?>
                 <div class="ui grid field settings-field-indicator-wrapper settings-field-indicator-edit-site-general" default-indi-value="2">
                     <label class="six wide column middle aligned">
                     <?php

--- a/class/class-mainwp-menu.php
+++ b/class/class-mainwp-menu.php
@@ -1299,7 +1299,7 @@ class MainWP_Menu { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Content
          *
          * @global object $mainwp_sub_leftmenu
          */
-        global $mainwp_sub_leftmenu, $_mainwp_menu_active_slugs;
+        global $mainwp_sub_leftmenu;
 
         $submenu_items = $mainwp_sub_leftmenu[ $parent_key ];
 
@@ -1360,7 +1360,7 @@ class MainWP_Menu { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Content
                         $level2_active = true;
                     }
 
-                    if ( ! $level2_active && ! isset( $_GET['do'] ) && 'InsightsManage' !== $page_name && 'admin.php?page=managesites' === $href ) {
+                    if ( ! $level2_active && ! isset( $_GET['do'] ) && 'InsightsManage' !== $page_name && 'Extensions-Mainwp-Clone-Extension' !== $page_name && 'admin.php?page=managesites' === $href ) {
                         $level2_active = true;
                     }
                 }

--- a/class/class-mainwp-system.php
+++ b/class/class-mainwp-system.php
@@ -29,7 +29,7 @@ class MainWP_System { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Conte
      *
      * @var string Current plugin version.
      */
-    public static $version = '5.4.0.7'; // NOSONAR.
+    public static $version = '5.4.0.8'; // NOSONAR.
 
     /**
      * Private static variable to hold the single instance of the class.

--- a/class/class-mainwp-ui-select-sites.php
+++ b/class/class-mainwp-ui-select-sites.php
@@ -168,6 +168,10 @@ class MainWP_UI_Select_Sites { // phpcs:ignore Generic.Classes.OpeningBraceSameL
         $selected_clients       = isset( $params['selected_clients'] ) ? $params['selected_clients'] : array();
         $add_edit_client_id     = isset( $params['add_edit_client_id'] ) ? $params['add_edit_client_id'] : false;
 
+        if ( ! \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
+            $show_client = false;
+        }
+
         if ( 'all' !== $selected_sites && ! is_array( $selected_sites ) ) {
             $selected_sites = array();
         }

--- a/class/class-mainwp-ui.php
+++ b/class/class-mainwp-ui.php
@@ -1346,7 +1346,9 @@ class MainWP_UI { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.ContentAf
             <i class="plus icon"></i>
             <div class="menu">
                 <a class="item" href="<?php echo esc_url( admin_url( 'admin.php?page=managesites&do=new' ) ); ?>"><?php esc_html_e( 'Add Website', 'mainwp' ); ?></a>
+                <?php if ( \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) { ?>
                 <a class="item" href="<?php echo esc_url( admin_url( 'admin.php?page=ClientAddNew' ) ); ?>"><?php esc_html_e( 'Add Client', 'mainwp' ); ?></a>
+                <?php } ?>
                 <a class="item" href="<?php echo esc_url( admin_url( 'admin.php?page=CostTrackerAdd' ) ); ?>"><?php esc_html_e( 'Add Cost', 'mainwp' ); ?></a>
                 <a class="item" href="<?php echo esc_url( admin_url( 'admin.php?page=PostBulkAdd' ) ); ?>"><?php esc_html_e( 'Create Post', 'mainwp' ); ?></a>
                 <a class="item" href="<?php echo esc_url( admin_url( 'admin.php?page=PageBulkAdd' ) ); ?>"><?php esc_html_e( 'Create Page', 'mainwp' ); ?></a>

--- a/class/class-mainwp-updates-table-helper.php
+++ b/class/class-mainwp-updates-table-helper.php
@@ -90,6 +90,9 @@ class MainWP_Updates_Table_Helper { // phpcs:ignore Generic.Classes.OpeningBrace
         if ( MAINWP_VIEW_PER_PLUGIN_THEME === $this->view_per ) {
             unset( $columns['trusted'] );
         }
+        if ( ! \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
+            unset( $columns['client'] );
+        }
         return $columns;
     }
 

--- a/includes/rest-api/class-mainwp-rest-authentication.php
+++ b/includes/rest-api/class-mainwp-rest-authentication.php
@@ -382,12 +382,7 @@ class MainWP_REST_Authentication { //phpcs:ignore -- NOSONAR - maximumMethodThre
         // If we have at least one supplied piece of data, and we have an error,
         // then it's a failed authentication.
         if ( ! empty( $errors ) ) {
-            $message = sprintf(
-                /* translators: %s: amount of errors */
-                _n( 'Missing OAuth parameter %s', 'Missing OAuth parameters %s', count( $errors ), 'mainwp' ),
-                implode( ', ', $errors )
-            );
-
+            $message = __( 'Invalid OAuth parameter.', 'mainwp' );
             $this->set_error( new WP_Error( 'mainwp_rest_authentication_missing_parameter', $message, array( 'status' => 401 ) ) );
 
             return array();

--- a/includes/rest-api/class-mainwp-rest-authentication.php
+++ b/includes/rest-api/class-mainwp-rest-authentication.php
@@ -544,14 +544,8 @@ class MainWP_REST_Authentication { //phpcs:ignore -- NOSONAR - maximumMethodThre
         // If we have at least one supplied piece of data, and we have an error,
         // then it's a failed authentication.
         if ( ! empty( $errors ) ) {
-            $message = sprintf(
-                /* translators: %s: amount of errors */
-                _n( 'Missing OAuth parameter %s', 'Missing OAuth parameters %s', count( $errors ), 'mainwp' ),
-                implode( ', ', $errors )
-            );
-
+            $message = __( 'Invalid OAuth parameter.', 'mainwp' );
             $this->set_error( new WP_Error( 'mainwp_rest_authentication_missing_parameter', $message, array( 'status' => 401 ) ) );
-
             return array();
         }
 

--- a/mainwp.php
+++ b/mainwp.php
@@ -8,7 +8,7 @@
  * Author URI: https://mainwp.com
  * Plugin URI: https://mainwp.com/
  * Text Domain: mainwp
- * Version:  5.4.0.7
+ * Version:  5.4.0.8
  *
  * @package MainWP/Dashboard
  *

--- a/pages/page-mainwp-manage-sites.php
+++ b/pages/page-mainwp-manage-sites.php
@@ -1497,7 +1497,7 @@ class MainWP_Manage_Sites { // phpcs:ignore Generic.Classes.OpeningBraceSameLine
         }
 
         // Load the Client widget.
-        if ( static::$enable_widgets['client_info'] ) {
+        if ( static::$enable_widgets['client_info'] && \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
             MainWP_UI::add_widget_box( 'client_info', array( MainWP_Client_Info::get_class_name(), 'render' ), static::$page, array( -1, -1, 3, 30 ) );
         }
 
@@ -1997,14 +1997,14 @@ class MainWP_Manage_Sites { // phpcs:ignore Generic.Classes.OpeningBraceSameLine
 
             MainWP_DB::instance()->update_website( $website->id, $url, $current_user->ID, $site_name, $site_admin, $groupids, $groupnames, $newPluginDir, $maximumFileDescriptorsOverride, $maximumFileDescriptorsAuto, $maximumFileDescriptors, $verifycertificate, $archiveFormat, $uniqueId, $http_user, $http_pass, $ssl_version, $disableHealthChecking, $healthThreshold, $backup_method );
 
-            $new_client_id = isset( $_POST['mainwp_managesites_edit_client_id'] ) ? intval( $_POST['mainwp_managesites_edit_client_id'] ) : 0;
-
-            if ( $website->client_id !== $new_client_id ) {
-
-                $update = array(
-                    'client_id' => $new_client_id,
-                );
-                MainWP_DB::instance()->update_website_values( $website->id, $update );
+            if ( \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
+                $new_client_id = isset( $_POST['mainwp_managesites_edit_client_id'] ) ? intval( $_POST['mainwp_managesites_edit_client_id'] ) : 0;
+                if ( $website->client_id !== $new_client_id ) {
+                    $update = array(
+                        'client_id' => $new_client_id,
+                    );
+                    MainWP_DB::instance()->update_website_values( $website->id, $update );
+                }
             }
 
             /**

--- a/pages/page-mainwp-manage-sites.php
+++ b/pages/page-mainwp-manage-sites.php
@@ -978,23 +978,25 @@ class MainWP_Manage_Sites { // phpcs:ignore Generic.Classes.OpeningBraceSameLine
                 </div>
             </div>
             <?php
-            $clients = MainWP_DB_Client::instance()->get_wp_client_by( 'all' );
-            ?>
-            <div class="ui grid field">
-                <label class="six wide column middle aligned"><?php esc_html_e( 'Client (optional)', 'mainwp' ); ?></label>
-                <div class="ten wide column" data-tooltip="<?php esc_attr_e( 'Add a client to the website.', 'mainwp' ); ?>" data-inverted="" data-position="top left">
-                    <div class="ui search selection dropdown" init-value="" id="mainwp_managesites_add_client_id">
-                        <i class="dropdown icon"></i>
-                        <div class="default text"></div>
-                        <div class="menu">
-                            <div class="item" data-value="0"><?php esc_attr_e( 'Select client', 'mainwp' ); ?></div>
-                            <?php foreach ( $clients as $client ) { ?>
-                                <div class="item" data-value="<?php echo intval( $client->client_id ); ?>"><?php echo esc_html( $client->name ); ?></div>
-                            <?php } ?>
+            if ( \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
+                $clients = MainWP_DB_Client::instance()->get_wp_client_by( 'all' );
+                ?>
+                <div class="ui grid field">
+                    <label class="six wide column middle aligned"><?php esc_html_e( 'Client (optional)', 'mainwp' ); ?></label>
+                    <div class="ten wide column" data-tooltip="<?php esc_attr_e( 'Add a client to the website.', 'mainwp' ); ?>" data-inverted="" data-position="top left">
+                        <div class="ui search selection dropdown" init-value="" id="mainwp_managesites_add_client_id">
+                            <i class="dropdown icon"></i>
+                            <div class="default text"></div>
+                            <div class="menu">
+                                <div class="item" data-value="0"><?php esc_attr_e( 'Select client', 'mainwp' ); ?></div>
+                                <?php foreach ( $clients as $client ) { ?>
+                                    <div class="item" data-value="<?php echo intval( $client->client_id ); ?>"><?php echo esc_html( $client->name ); ?></div>
+                                <?php } ?>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            <?php } ?>
 
             <!-- fake fields are a workaround for chrome autofill getting the wrong fields. -->
             <input style="display:none" type="text" name="fakeusernameremembered"/>

--- a/pages/page-mainwp-overview.php
+++ b/pages/page-mainwp-overview.php
@@ -246,7 +246,7 @@ class MainWP_Overview { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Con
         }
 
         // Load the Clients widget.
-        if ( static::$enable_widgets['clients'] ) {
+        if ( static::$enable_widgets['clients'] && \mainwp_current_user_can( 'dashboard', 'manage_clients' ) ) {
             MainWP_UI::add_widget_box( 'clients', array( MainWP_Clients::get_class_name(), 'render' ), $page, array( -1, -1, 4, 30 ) );
         }
 

--- a/pages/page-mainwp-updates-per-group.php
+++ b/pages/page-mainwp-updates-per-group.php
@@ -46,7 +46,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
      * @uses \MainWP\Dashboard\MainWP_Updates::render_site_link_dashboard()
      */
     public static function render_wpcore_updates( $websites, $userExtension, $total_wp_upgrades, $all_groups_sites, $all_groups, $site_offset_for_groups ) { // phpcs:ignore -- NOSONAR - complex method. Current complexity is the only way to achieve desired results, pull request solutions appreciated.
-
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         $decodedIgnoredCores = ! empty( $userExtension->ignored_wp_upgrades ) ? json_decode( $userExtension->ignored_wp_upgrades, true ) : array();
         if ( ! is_array( $decodedIgnoredCores ) ) {
             $decodedIgnoredCores = array();
@@ -100,7 +100,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                             <th scope="col" ><?php esc_html_e( 'Website', 'mainwp' ); ?></th>
                                             <th scope="col" ><?php esc_html_e( 'Version', 'mainwp' ); ?></th>
                                             <th scope="col" class="no-sort"><?php esc_html_e( 'Latest', 'mainwp' ); ?></th>
+                                            <?php if ( $user_can_see_client ) { ?>
                                             <th scope="col" ><?php esc_html_e( 'Client', 'mainwp' ); ?></th>
+                                            <?php } ?>
                                             <th scope="col" class="no-sort"></th>
                                         </tr>
                                     </thead>
@@ -151,7 +153,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                                         <strong class="mainwp-768-show"><?php esc_html_e( 'Latest:', 'mainwp' ); ?></strong> <?php echo esc_html( $wp_upgrades['new'] ); ?>
                                                     <?php endif; ?>
                                                 </td>
+                                                <?php if ( $user_can_see_client ) { ?>
                                                 <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                                                <?php } ?>
                                                 <td>
                                                     <?php if ( MainWP_Updates::user_can_update_wp() ) : ?>
                                                         <?php if ( ! empty( $wp_upgrades ) ) : ?>
@@ -214,6 +218,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
      */
     public static function render_plugins_updates( $websites, $total_plugin_upgrades, $userExtension, $all_groups_sites, $all_groups, $site_offset_for_groups, $trustedPlugins ) { // phpcs:ignore -- NOSONAR - complex.
         $updates_table_helper = new MainWP_Updates_Table_Helper( $userExtension->site_view );
+        $user_can_see_client  = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         ?>
         <?php if ( 0 < $total_plugin_upgrades ) : ?>
         <table class="ui tablet stackable table mainwp-manage-updates-table main-master-checkbox" id="mainwp-plugins-updates-groups-table">
@@ -265,7 +270,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                         <th scope="col" class="collapsing no-sort"></th>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Website', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Updates', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                                        <?php if ( $user_can_see_client ) { ?>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                                        <?php } ?>
                                         <th scope="col" class="collapsing no-sort"></th>
                                     </tr>
                                 </thead>
@@ -345,7 +352,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                                 </div>
                                             </td>
                                             <td sort-value="<?php echo count( $plugin_upgrades ); ?>"><strong class="mainwp-768-show"><?php echo esc_html__( 'Updates: ', 'mainwp' ); ?></strong> <?php echo count( $plugin_upgrades ) . ' ' . esc_html( _n( 'Update', 'Updates', count( $plugin_upgrades ), 'mainwp' ) ); ?></td>
+                                            <?php if ( $user_can_see_client ) { ?>
                                             <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                                            <?php } ?>
                                             <td>
                                                 <?php if ( MainWP_Updates::user_can_update_plugins() ) : ?>
                                                     <?php if ( ! empty( $plugin_upgrades ) ) : ?>
@@ -457,6 +466,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
      */
     public static function render_themes_updates( $websites, $total_theme_upgrades, $userExtension, $all_groups_sites, $all_groups, $site_offset_for_groups, $trustedThemes ) { // phpcs:ignore -- NOSONAR - complex.
         $updates_table_helper = new MainWP_Updates_Table_Helper( $userExtension->site_view, 'theme' );
+        $user_can_see_client  = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         ?>
         <?php if ( 0 < $total_theme_upgrades ) : ?>
         <table class="ui tablet stackable table mainwp-manage-updates-table main-master-checkbox" id="mainwp-themes-updates-groups-table">
@@ -506,7 +516,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                         <th scope="col" class="collapsing no-sort"></th>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Website', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Updates', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                                        <?php if ( $user_can_see_client ) { ?>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                                        <?php } ?>
                                         <th scope="col" class="collapsing no-sort"></th>
                                     </tr>
                                 </thead>
@@ -581,7 +593,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                                 </div>
                                             </td>
                                             <td sort-value="<?php echo count( $theme_upgrades ); ?>"><strong class="mainwp-768-show"><?php esc_html_e( 'Updates:', 'mainwp' ); ?></strong> <?php echo count( $theme_upgrades ) . ' ' . esc_html( _n( 'Update', 'Updates', count( $theme_upgrades ), 'mainwp' ) ); ?></td>
+                                            <?php if ( $user_can_see_client ) { ?>
                                             <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                                            <?php } ?>
                                             <td class="right aligned">
                                                 <?php if ( MainWP_Updates::user_can_update_themes() ) : ?>
                                                     <?php if ( ! empty( $theme_upgrades ) ) : ?>
@@ -682,6 +696,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
      * @uses \MainWP\Dashboard\MainWP_Updates::render_site_link_dashboard()
      */
     public static function render_trans_update( $websites, $total_translation_upgrades, $all_groups_sites, $all_groups, $site_offset_for_groups, $userExtension ) { //phpcs:ignore -- NOSONAR - complex method.
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
 
         $trustedPlugins = ! empty( $userExtension->trusted_plugins ) ? json_decode( $userExtension->trusted_plugins, true ) : array();
         if ( ! is_array( $trustedPlugins ) ) {
@@ -740,7 +755,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                         <th scope="col" class="collapsing no-sort"></th>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Website', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Updates', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                                        <?php if ( $user_can_see_client ) { ?>
                                         <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                                        <?php } ?>
                                         <th scope="col" ></th>
                                     </tr>
                                 </thead>
@@ -770,7 +787,9 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                         <td sort-value="<?php echo count( $translation_upgrades ); ?>">
                                             <strong class="mainwp-768-show"><?php esc_html_e( 'Updates:', 'mainwp' ); ?></strong> <?php echo esc_html( _n( 'Update', 'Updates', count( $translation_upgrades ), 'mainwp' ) ); ?>
                                         </td>
+                                        <?php if ( $user_can_see_client ) { ?>
                                         <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                                        <?php } ?>
                                         <td>
                                         <?php if ( MainWP_Updates::user_can_update_trans() ) : ?>
                                             <?php if ( ! empty( $translation_upgrades ) ) : ?>

--- a/pages/page-mainwp-updates-per-item.php
+++ b/pages/page-mainwp-updates-per-item.php
@@ -432,7 +432,7 @@ class MainWP_Updates_Per_Item { // phpcs:ignore Generic.Classes.OpeningBraceSame
      * @uses \MainWP\Dashboard\MainWP_Updates::render_site_link_dashboard()
      */
     public static function render_trans_update( $websites, $total_translation_upgrades, $userExtension, $allTranslations, $translationsInfo ) { // phpcs:ignore -- NOSONAR - complex.
-
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         $trustedPlugins = ! empty( $userExtension->trusted_plugins ) ? json_decode( $userExtension->trusted_plugins, true ) : array();
         if ( ! is_array( $trustedPlugins ) ) {
             $trustedPlugins = array();
@@ -491,7 +491,9 @@ class MainWP_Updates_Per_Item { // phpcs:ignore Generic.Classes.OpeningBraceSame
                                         <th scope="col"><?php esc_html_e( 'Website', 'mainwp' ); ?></th>
                                         <th scope="col"><?php esc_html_e( 'Version', 'mainwp' ); ?></th>
                                         <th scope="col" ><?php esc_html_e( 'Trusted', 'mainwp' ); ?></th>
+                                        <?php if ( $user_can_see_client ) { ?>
                                         <th scope="col"><?php esc_html_e( 'Client', 'mainwp' ); ?></th>
+                                        <?php } ?>
                                         <th scope="col" class="collapsing no-sort"></th>
                                     </tr>
                                 </thead>
@@ -524,7 +526,9 @@ class MainWP_Updates_Per_Item { // phpcs:ignore Generic.Classes.OpeningBraceSame
                                             $is_trust = MainWP_Manage_Sites_Update_View::is_trans_trusted_update( $translation_upgrade, $trustedPlugins, $trustedThemes );
                                             echo MainWP_Manage_Sites_Update_View::get_column_trusted($is_trust ); //phpcs:ignore -- NOSONAR - escaped.
                                             ?>
+                                            <?php if( $user_can_see_client ) { ?>
                                             <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                                            <?php } ?>
                                             <td class="right aligned">
                                                 <?php if ( MainWP_Updates::user_can_update_trans() ) : ?>
                                                     <a href="javascript:void(0)" class="mainwp-update-now-button ui green mini button" onClick="return updatesoverview_upgrade_translation( <?php echo esc_attr( $website->id ); ?>, '<?php echo esc_js( $slug ); ?>' )"><?php esc_html_e( 'Update', 'mainwp' ); ?></a>

--- a/pages/page-mainwp-updates-per-item.php
+++ b/pages/page-mainwp-updates-per-item.php
@@ -433,7 +433,7 @@ class MainWP_Updates_Per_Item { // phpcs:ignore Generic.Classes.OpeningBraceSame
      */
     public static function render_trans_update( $websites, $total_translation_upgrades, $userExtension, $allTranslations, $translationsInfo ) { // phpcs:ignore -- NOSONAR - complex.
         $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
-        $trustedPlugins = ! empty( $userExtension->trusted_plugins ) ? json_decode( $userExtension->trusted_plugins, true ) : array();
+        $trustedPlugins      = ! empty( $userExtension->trusted_plugins ) ? json_decode( $userExtension->trusted_plugins, true ) : array();
         if ( ! is_array( $trustedPlugins ) ) {
             $trustedPlugins = array();
         }
@@ -526,7 +526,7 @@ class MainWP_Updates_Per_Item { // phpcs:ignore Generic.Classes.OpeningBraceSame
                                             $is_trust = MainWP_Manage_Sites_Update_View::is_trans_trusted_update( $translation_upgrade, $trustedPlugins, $trustedThemes );
                                             echo MainWP_Manage_Sites_Update_View::get_column_trusted($is_trust ); //phpcs:ignore -- NOSONAR - escaped.
                                             ?>
-                                            <?php if( $user_can_see_client ) { ?>
+                                            <?php if ( $user_can_see_client ) { ?>
                                             <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
                                             <?php } ?>
                                             <td class="right aligned">

--- a/pages/page-mainwp-updates-per-site.php
+++ b/pages/page-mainwp-updates-per-site.php
@@ -40,7 +40,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
      * @uses \MainWP\Dashboard\MainWP_Updates::render_site_link_dashboard()
      */
     public static function render_wpcore_updates( $websites, $userExtension, $total_wp_upgrades ) { //phpcs:ignore -- NOSONAR - complex method.
-
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         $decodedIgnoredCores = ! empty( $userExtension->ignored_wp_upgrades ) ? json_decode( $userExtension->ignored_wp_upgrades, true ) : array();
         if ( ! is_array( $decodedIgnoredCores ) ) {
             $decodedIgnoredCores = array();
@@ -59,7 +59,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                     </th>
                     <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Version', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
                     <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Latest', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php if( $user_can_see_client ) { ?>
                     <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php } ?>
                     <th scope="col" class="no-sort right aligned"></th>
                 </tr>
             </thead>
@@ -103,7 +105,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                     <td>
                         <?php echo esc_html( $last_version ); ?>
                     </td>
+                    <?php if( $user_can_see_client ) { ?>
                     <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                    <?php } ?>
                     <td class="right aligned">
                         <?php if ( MainWP_Updates::user_can_update_wp() ) : ?>
                             <?php
@@ -161,6 +165,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
      * @uses \MainWP\Dashboard\MainWP_Updates::user_can_ignore_updates()
      */
     public static function render_plugins_updates( $websites, $total_plugin_upgrades, $userExtension, $trustedPlugins ) { // phpcs:ignore -- NOSONAR - not quite complex method.
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         ?>
         <?php if ( 0 < $total_plugin_upgrades ) : ?>
         <table class="ui tablet stackable table mainwp-manage-updates-table main-master-checkbox" id="mainwp-plugins-updates-sites-table">
@@ -175,7 +180,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                         <?php MainWP_UI::render_sorting_icons(); ?>
                     </th>
                     <th scope="col" class="two wide indicator-accordion-sorting handle-accordion-sorting"><?php echo intval( $total_plugin_upgrades ) . ' ' . esc_html( _n( 'Update', 'Updates', $total_plugin_upgrades, 'mainwp' ) ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php if ( $user_can_see_client ) { ?>
                     <th scope="col" class="two wide collapsing indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php } ?>
                     <th scope="col" class="four wide no-sort right aligned">
                         <?php MainWP_UI::render_show_all_updates_button(); ?>
                     </th>
@@ -247,7 +254,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                             </div>
                         </td>
                         <td sort-value="<?php echo count( $plugin_upgrades ); ?>"><?php echo count( $plugin_upgrades ); ?> <?php echo esc_html( _n( 'Update', 'Updates', count( $plugin_upgrades ), 'mainwp' ) ); ?></td>
+                        <?php if ( $user_can_see_client ) { ?>
                         <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                        <?php } ?>
                         <td class="right aligned">
                         <?php if ( MainWP_Updates::user_can_update_plugins() ) : ?>
                             <?php if ( ! empty( $plugin_upgrades ) ) : ?>
@@ -350,6 +359,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
      * @uses \MainWP\Dashboard\MainWP_Updates::render_site_link_dashboard()
      */
     public static function render_themes_updates( $websites, $total_theme_upgrades, $userExtension, $trustedThemes ) { // phpcs:ignore -- NOSONAR - complex.
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
         ?>
         <?php if ( 0 < $total_theme_upgrades ) : ?>
         <table class="ui tablet stackable table mainwp-manage-updates-table main-master-checkbox" id="mainwp-themes-updates-sites-table">
@@ -363,7 +373,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                     <?php MainWP_UI::render_sorting_icons(); ?>
                     </th>
                     <th scope="col" class="two wide indicator-accordion-sorting handle-accordion-sorting"><?php echo intval( $total_theme_upgrades ) . ' ' . esc_html( _n( 'Update', 'Updates', $total_theme_upgrades, 'mainwp' ) ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php if ( $user_can_see_client ) { ?>
                     <th scope="col" class="two wide indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php } ?>
                     <th scope="col" class="four wide no-sort right aligned">
                         <?php MainWP_UI::render_show_all_updates_button(); ?>
                     </th>
@@ -431,7 +443,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                             </div>
                         </td>
                         <td sort-value="<?php echo count( $theme_upgrades ); ?>"><?php echo count( $theme_upgrades ); ?> <?php echo esc_html( _n( 'Update', 'Updates', count( $theme_upgrades ), 'mainwp' ) ); ?></td>
+                        <?php if ( $user_can_see_client ) { ?>
                         <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                        <?php } ?>
                         <td class="right aligned">
                         <?php if ( MainWP_Updates::user_can_update_themes() ) : ?>
                             <?php if ( ! empty( $theme_upgrades ) ) : ?>
@@ -527,6 +541,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
      * @uses \MainWP\Dashboard\MainWP_Updates::render_site_link_dashboard()
      */
     public static function render_trans_update( $websites, $total_translation_upgrades, $userExtension ) {  //phpcs:ignore -- NOSONAR - complex.
+        $user_can_see_client = \mainwp_current_user_can( 'dashboard', 'manage_clients' );
 
         $trustedPlugins = ! empty( $userExtension->trusted_plugins ) ? json_decode( $userExtension->trusted_plugins, true ) : array();
         if ( ! is_array( $trustedPlugins ) ) {
@@ -551,7 +566,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                     <span class="mainwp-768-hide"><?php MainWP_UI::render_sorting_icons(); ?></span>
                     </th>
                     <th scope="col" class="two wide indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Updates', 'mainwp' ); ?><span class="mainwp-768-hide"><?php MainWP_UI::render_sorting_icons(); ?></span></th>
+                    <?php if ( $user_can_see_client ) { ?>
                     <th scope="col" class="two wide indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
+                    <?php } ?>
                     <th scope="col" class="four wide right aligned"><?php MainWP_UI::render_show_all_updates_button(); ?></th>
                 </tr>
             </thead>
@@ -574,7 +591,9 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                         <td sort-value="<?php echo count( $translation_upgrades ); ?>">
                             <?php echo count( $translation_upgrades ); ?><?php echo esc_html( _n( 'Update', 'Updates', count( $translation_upgrades ), 'mainwp' ) ); ?>
                         </td>
+                        <?php if( $user_can_see_client ) { ?>
                         <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
+                        <?php } ?>
                         <td class="right aligned">
                         <?php if ( MainWP_Updates::user_can_update_trans() ) : ?>
                             <?php if ( ! empty( $translation_upgrades ) ) : ?>

--- a/pages/page-mainwp-updates-per-site.php
+++ b/pages/page-mainwp-updates-per-site.php
@@ -59,7 +59,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                     </th>
                     <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Version', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
                     <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php esc_html_e( 'Latest', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
-                    <?php if( $user_can_see_client ) { ?>
+                    <?php if ( $user_can_see_client ) { ?>
                     <th scope="col" class="indicator-accordion-sorting handle-accordion-sorting"><?php echo esc_html__( 'Client', 'mainwp' ); ?><?php MainWP_UI::render_sorting_icons(); ?></th>
                     <?php } ?>
                     <th scope="col" class="no-sort right aligned"></th>
@@ -105,7 +105,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                     <td>
                         <?php echo esc_html( $last_version ); ?>
                     </td>
-                    <?php if( $user_can_see_client ) { ?>
+                    <?php if ( $user_can_see_client ) { ?>
                     <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
                     <?php } ?>
                     <td class="right aligned">
@@ -591,7 +591,7 @@ class MainWP_Updates_Per_Site { // phpcs:ignore Generic.Classes.OpeningBraceSame
                         <td sort-value="<?php echo count( $translation_upgrades ); ?>">
                             <?php echo count( $translation_upgrades ); ?><?php echo esc_html( _n( 'Update', 'Updates', count( $translation_upgrades ), 'mainwp' ) ); ?>
                         </td>
-                        <?php if( $user_can_see_client ) { ?>
+                        <?php if ( $user_can_see_client ) { ?>
                         <td><a href="<?php echo 'admin.php?page=ManageClients&client_id=' . intval( $website->client_id ); ?>" data-tooltip="<?php esc_attr_e( 'Jump to the client', 'mainwp' ); ?>" data-position="right center" data-inverted="" ><?php echo esc_html( $website->client_name ); ?></a></td>
                         <?php } ?>
                         <td class="right aligned">

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Author: mainwp
 Author URI: https://mainwp.com
 Plugin URI: https://mainwp.com
 Requires at least: 6.2
-Tested up to: 6.8
+Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 5.4.0.7
+Stable tag: 5.4.0.8
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -146,6 +146,16 @@ Yes, we have a quick FAQ with many more questions and answers [here](https://mai
 10. Dashboard Insights
 
 == Changelog ==
+
+= 5.4.0.8 - Maintenance Release - 5-6-2025 =
+
+* Fixed: Incorrect type property for the Vulnerability Checker which made it appear as a Pro add-on.
+* Fixed: Missing error message tooltip from X icon that shows when translation update fails. (#773)[https://github.com/mainwp/mainwp/issues/773]
+* Fixed: Issue with incorrect menu item being selected when on the Clone add-on page.
+* Fixed: Specific UI elements did not respect Team control permissions, causing client information to be exposed to users with permission to Manage clients. (#776)[https://github.com/mainwp/mainwp/issues/776]
+* Updated: Modal behavior to prevent auto-closing when at least one translation update fails. (#773)[https://github.com/mainwp/mainwp/issues/773]
+* Updated: Error message that displays when calls fail due to invalid authentication parameters.
+* Updated: Database Updater table background in Dark theme for improved visibility. (#779)[https://github.com/mainwp/mainwp/issues/779]
 
 = 5.4.0.7 - Maintenance Release - 4-29-2025 =
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Vulnerability Checker" extension is now available as a free extension.

- **Improvements**
  - Client management options and UI elements are now only visible to users with the appropriate permissions.
  - The "Clients" widget on the Overview and Manage Sites pages is now restricted to users with client management permissions.
  - Updates to error messages for OAuth authentication provide clearer, more generic feedback when parameters are missing.
  - Enhanced error messages and UI popups for translation update failures improve clarity during bulk updates.
  - Dark theme styling updated for better visibility in the Database Updater table.

- **Bug Fixes**
  - Fixed incorrect menu item selection on the Clone add-on page.
  - Prevented modal auto-closing on translation update failures to allow error review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->