### PR TITLE
Fixed: typo

### DIFF
--- a/class/class-mainwp-system.php
+++ b/class/class-mainwp-system.php
@@ -29,7 +29,7 @@ class MainWP_System { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Conte
      *
      * @var string Current plugin version.
      */
-    public static $version = '5.4.0.9'; // NOSONAR.
+    public static $version = '5.4.0.10'; // NOSONAR.
 
     /**
      * Private static variable to hold the single instance of the class.

--- a/mainwp.php
+++ b/mainwp.php
@@ -8,7 +8,7 @@
  * Author URI: https://mainwp.com
  * Plugin URI: https://mainwp.com/
  * Text Domain: mainwp
- * Version:  5.4.0.9
+ * Version:  5.4.0.10
  *
  * @package MainWP/Dashboard
  *

--- a/pages/page-mainwp-settings.php
+++ b/pages/page-mainwp-settings.php
@@ -1693,7 +1693,7 @@ class MainWP_Settings { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Con
                             esc_html_e( 'Force IPv4', 'mainwp' );
                             ?>
                             </label>
-                            <div class="ten wide column ui toggle checkbox"  data-tooltip="<?php esc_attr_e( 'Enable if you want to force your MainWP Dashboard to use IPv4 while tryig to connect child sites.', 'mainwp' ); ?>" data-inverted="" data-position="bottom left">
+                            <div class="ten wide column ui toggle checkbox"  data-tooltip="<?php esc_attr_e( 'Enable if you want to force your MainWP Dashboard to use IPv4 while trying to connect child sites.', 'mainwp' ); ?>" data-inverted="" data-position="bottom left">
                                 <input type="checkbox" class="settings-field-value-change-handler" name="mainwp_forceUseIPv4" id="mainwp_forceUseIPv4" value="checked" <?php echo ( 1 === (int) get_option( 'mainwp_forceUseIPv4' ) ) ? 'checked="checked"' : ''; ?>/><label><?php esc_html_e( 'Default: Off', 'mainwp' ); ?></label>
                             </div>
                         </div>

--- a/pages/page-mainwp-updates.php
+++ b/pages/page-mainwp-updates.php
@@ -2475,7 +2475,7 @@ class MainWP_Updates { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
                     </div>
                     <div class="ui grid field">
                         <label class="six wide column middle aligned"><?php esc_html_e( 'Translation advanced automatic updates', 'mainwp' ); ?></label>
-                        <div class="ten wide column" data-tooltip="<?php esc_attr_e( 'Enable or disabled automatic translation updates.', 'mainwp' ); ?>" data-inverted="" data-position="top left">
+                        <div class="ten wide column" data-tooltip="<?php esc_attr_e( 'Enable or disable automatic translation updates.', 'mainwp' ); ?>" data-inverted="" data-position="top left">
                             <select name="mainwp_transAutomaticDailyUpdate" id="mainwp_transAutomaticDailyUpdate" class="ui dropdown">
                                 <option value="1" <?php echo 1 === $snTransAutomaticUpdate ? 'selected' : ''; ?>><?php esc_html_e( 'Install Trusted Updates', 'mainwp' ); ?></option>
                                 <option value="0" <?php echo ( false !== $snTransAutomaticUpdate && 0 === $snTransAutomaticUpdate ) || 2 === $snTransAutomaticUpdate ? 'selected' : ''; ?>><?php esc_html_e( 'Disabled', 'mainwp' ); ?></option>

--- a/pages/page-mainwp-updates.php
+++ b/pages/page-mainwp-updates.php
@@ -2474,8 +2474,8 @@ class MainWP_Updates { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
                         </div>
                     </div>
                     <div class="ui grid field">
-                        <label class="six wide column middle aligned"><?php esc_html_e( 'Theme advanced automatic updates', 'mainwp' ); ?></label>
-                        <div class="ten wide column" data-tooltip="<?php esc_attr_e( 'Enable or disable automatic theme updates.', 'mainwp' ); ?>" data-inverted="" data-position="top left">
+                        <label class="six wide column middle aligned"><?php esc_html_e( 'Translation advanced automatic updates', 'mainwp' ); ?></label>
+                        <div class="ten wide column" data-tooltip="<?php esc_attr_e( 'Enable or disabled automatic translation updates.', 'mainwp' ); ?>" data-inverted="" data-position="top left">
                             <select name="mainwp_transAutomaticDailyUpdate" id="mainwp_transAutomaticDailyUpdate" class="ui dropdown">
                                 <option value="1" <?php echo 1 === $snTransAutomaticUpdate ? 'selected' : ''; ?>><?php esc_html_e( 'Install Trusted Updates', 'mainwp' ); ?></option>
                                 <option value="0" <?php echo ( false !== $snTransAutomaticUpdate && 0 === $snTransAutomaticUpdate ) || 2 === $snTransAutomaticUpdate ? 'selected' : ''; ?>><?php esc_html_e( 'Disabled', 'mainwp' ); ?></option>

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Plugin URI: https://mainwp.com
 Requires at least: 6.2
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 5.4.0.9
+Stable tag: 5.4.0.10
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -146,6 +146,11 @@ Yes, we have a quick FAQ with many more questions and answers [here](https://mai
 10. Dashboard Insights
 
 == Changelog ==
+
+= 5.4.0.10 - Maintenance Release - 5-20-2025 =
+
+* Fixed: Corrected a typo in the Force IPv4 option tooltip for improved clarity. [(#787)](https://github.com/mainwp/mainwp/issues/787)
+* Fixed: Changed incorrect "Theme advanced automatic updates" option label to "Translation advanced automatic updates" and updated the corresponding tooltip to accurately reflect its function.
 
 = 5.4.0.9 - Maintenance Release - 5-13-2025 =
 


### PR DESCRIPTION
Fixed: text for update translations settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the tooltip for the "Force IPv4" checkbox on the Advanced Settings page.
  - Updated the label and tooltip in the screen options modal to accurately describe the automatic translation updates setting instead of theme updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->