### PR TITLE
Mainwp 5.4.0.16

### DIFF
--- a/class/class-mainwp-notification-settings.php
+++ b/class/class-mainwp-notification-settings.php
@@ -595,13 +595,14 @@ class MainWP_Notification_Settings { // phpcs:ignore Generic.Classes.OpeningBrac
      *
      * @param string $type    Email type.
      * @param object $website Object containing the child site information.
+     * @param mixed  $website_status Object containing the child site status.
      *
      * @return array An array containing the email settings.
      *
      * @uses \MainWP\Dashboard\MainWP_System_Utility::get_tokens_site_values()
      * @uses \MainWP\Dashboard\MainWP_System_Utility::replace_tokens_values()
      */
-    public static function get_site_email_settings( $type, $website ) {
+    public static function get_site_email_settings( $type, $website, $website_status = false ) {
         if ( empty( $website ) || ! property_exists( $website, 'settings_notification_emails' ) ) {
             return array( 'disable' => 1 );
         }
@@ -619,7 +620,7 @@ class MainWP_Notification_Settings { // phpcs:ignore Generic.Classes.OpeningBrac
         $options = array_merge( $default, $options );
 
         if ( preg_match( '/\[[^\]]+\]/is', $options['subject'] . $options['heading'], $matches ) ) {
-            $tokens_values      = MainWP_System_Utility::get_tokens_site_values( $website, true );
+            $tokens_values      = MainWP_System_Utility::get_tokens_site_values( $website, true, $website_status );
             $options['subject'] = MainWP_System_Utility::replace_tokens_values( $options['subject'], $tokens_values );
             $options['heading'] = MainWP_System_Utility::replace_tokens_values( $options['heading'], $tokens_values );
         }

--- a/class/class-mainwp-system.php
+++ b/class/class-mainwp-system.php
@@ -29,7 +29,7 @@ class MainWP_System { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Conte
      *
      * @var string Current plugin version.
      */
-    public static $version = '5.4.0.15'; // NOSONAR.
+    public static $version = '5.4.0.16'; // NOSONAR.
 
     /**
      * Private static variable to hold the single instance of the class.

--- a/class/class-mainwp-uptime-monitoring-schedule.php
+++ b/class/class-mainwp-uptime-monitoring-schedule.php
@@ -330,7 +330,7 @@ class MainWP_Uptime_Monitoring_Schedule { // phpcs:ignore Generic.Classes.Openin
                             $new_obj                = clone $notice;  // to fix reference to object.
                             $new_obj->hb_http_code  = $hb_notice->http_code; // to fix for monitor with multi heartbeats down status.
                             $new_obj->status        = $hb_notice->status;
-                            $new_obj->hb_time_check = strtotime( $hb_notice->time );
+                            $new_obj->hb_time_check = strtotime( $hb_notice->time . ' UTC' );
                             $heartbeats_notices[]   = $new_obj;
                         }
                     }

--- a/class/class-mainwp-uptime-monitoring-schedule.php
+++ b/class/class-mainwp-uptime-monitoring-schedule.php
@@ -253,10 +253,6 @@ class MainWP_Uptime_Monitoring_Schedule { // phpcs:ignore Generic.Classes.Openin
         // general uptime notification, to administrator.
         $gene_email_settings = MainWP_Notification_Settings::get_general_email_settings( 'uptime' );
 
-        if ( ! empty( $process_notices ) ) {
-            MainWP_Notification_Settings::prepare_general_email_settings_for_site( $gene_email_settings, $process_notices[0] );
-        }
-
         $debug_settings = array(
             'admin_email'            => $admin_email,
             'general_email_settings' => $admin_email,
@@ -265,7 +261,7 @@ class MainWP_Uptime_Monitoring_Schedule { // phpcs:ignore Generic.Classes.Openin
 
         if ( ! $gene_email_settings['disable'] ) {
             MainWP_Logger::instance()->log_uptime_notice( 'General uptime notifications are now being sent to the admin.' );
-            static::send_uptime_notification_heartbeats_importance_status( $process_notices, $admin_email, $gene_email_settings, $plain_text );
+            static::send_uptime_notification_heartbeats_importance_status( $process_notices, $admin_email, $gene_email_settings, $plain_text, false, true );
         }
 
         $individual_admin_uptimeSites = array();
@@ -297,10 +293,9 @@ class MainWP_Uptime_Monitoring_Schedule { // phpcs:ignore Generic.Classes.Openin
             $admin_email_settings               = MainWP_Notification_Settings::get_default_emails_fields( 'uptime', '', true ); // get default subject and heading only.
             $admin_email_settings['disable']    = 0;
             $admin_email_settings['recipients'] = ''; // sent to admin only.
-            MainWP_Notification_Settings::prepare_general_email_settings_for_site( $admin_email_settings, $uptime_notice );
             // send to admin, all individual sites in one email.
             MainWP_Logger::instance()->log_uptime_notice( 'Send all individual uptime notifications to the admin in a single email. [count=' . count( $individual_admin_uptimeSites ) . ']' );
-            static::send_uptime_notification_heartbeats_importance_status( $individual_admin_uptimeSites, $admin_email, $admin_email_settings, $plain_text, true );
+            static::send_uptime_notification_heartbeats_importance_status( $individual_admin_uptimeSites, $admin_email, $admin_email_settings, $plain_text, true, true );
         }
         MainWP_Logger::instance()->log_uptime_notice( 'Uptime notifications email settings :: debug :: ' . print_r( $debug_settings, true ) ); //phpcs:ignore -- NOSONAR -ok.
         return true;
@@ -315,12 +310,17 @@ class MainWP_Uptime_Monitoring_Schedule { // phpcs:ignore Generic.Classes.Openin
      * @param string $email_settings Email settings.
      * @param bool   $plain_text     Determines if the plain text format should be used.
      * @param bool   $to_admin Send to admin or not.
+     * @param bool   $need_to_prepared_tokens Need to check and replace tokens in email settings, or not.
      *
      * @uses \MainWP\Dashboard\MainWP_DB::update_website_values()
      * @uses \MainWP\Dashboard\MainWP_Notification_Template::get_template_html()
      */
-    public static function send_uptime_notification_heartbeats_importance_status( $uptime_notices, $admin_email, $email_settings, $plain_text, $to_admin = false ) { //phpcs:ignore -- NOSONAR - complex.
+    public static function send_uptime_notification_heartbeats_importance_status( $uptime_notices, $admin_email, $email_settings, $plain_text, $to_admin = false, $need_to_prepared_tokens = false ) { //phpcs:ignore -- NOSONAR - complex.
         if ( is_array( $uptime_notices ) ) {
+
+            $current_mo        = false;
+            $current_heartbeat = false;
+
             $heartbeats_notices = array();
             foreach ( $uptime_notices as $notice ) {
                 if ( ! empty( $notice->dts_process_init_time ) ) {
@@ -332,11 +332,19 @@ class MainWP_Uptime_Monitoring_Schedule { // phpcs:ignore Generic.Classes.Openin
                             $new_obj->status        = $hb_notice->status;
                             $new_obj->hb_time_check = strtotime( $hb_notice->time . ' UTC' );
                             $heartbeats_notices[]   = $new_obj;
+
+                            if ( $need_to_prepared_tokens && false === $current_heartbeat ) {
+                                $current_mo        = $notice;
+                                $current_heartbeat = $new_obj;
+                            }
                         }
                     }
                 }
             }
             if ( ! empty( $heartbeats_notices ) ) {
+                if ( $need_to_prepared_tokens && $current_mo && $current_heartbeat ) {
+                    MainWP_Notification_Settings::prepare_general_email_settings_for_site( $email_settings, $current_mo, $current_heartbeat );
+                }
                 MainWP_Logger::instance()->log_uptime_notice( 'Uptime notification :: heartbeats :: [count=' . count( $heartbeats_notices ) . ']' );
                 MainWP_Monitoring_Handler::notice_sites_uptime_monitoring( $heartbeats_notices, $admin_email, $email_settings, $plain_text, $to_admin );
             }

--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -394,20 +394,28 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
      * Format the given timestamp.
      *
      * @param mixed $timestamp Timestamp to format.
+     * @param mixed $with_tz_info Return date time with timezone infor.
      *
      * @return string Formatted timestamp.
      */
-    public static function format_timezone( $timestamp ) {
-
+    public static function format_timezone( $timestamp, $with_tz_info = false ) {
+        $tzinfo      = '';
         $wp_timezone = get_option( 'timezone_string' );
         if ( ! $wp_timezone ) {
-            return static::format_timestamp( static::get_timestamp( $timestamp ) );
+            if ( $with_tz_info ) {
+                $tzinfo = ' ( UTC ' . get_option( 'gmt_offset' ) . ' )';
+            }
+            return static::format_timestamp( static::get_timestamp( $timestamp ) ) . $tzinfo;
+        }
+
+        if ( $with_tz_info ) {
+            $tzinfo = ' ( ' . $wp_timezone . ' )';
         }
 
         $datetime = new \DateTime( '@' . $timestamp );
         $datetime->setTimezone( new \DateTimeZone( $wp_timezone ) );
 
-        $format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+        $format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) . $tzinfo;
         return $datetime->format( $format );
     }
 

--- a/mainwp.php
+++ b/mainwp.php
@@ -8,7 +8,7 @@
  * Author URI: https://mainwp.com
  * Plugin URI: https://mainwp.com/
  * Text Domain: mainwp
- * Version:  5.4.0.15
+ * Version:  5.4.0.16
  *
  * @package MainWP/Dashboard
  *

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Author: mainwp
 Author URI: https://mainwp.com
 Plugin URI: https://mainwp.com
 Requires at least: 6.2
-Tested up to: 6.8.1
+Tested up to: 6.8.2
 Requires PHP: 7.4
 Stable tag: 5.4.0.16
 License: GPLv3 or later

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Plugin URI: https://mainwp.com
 Requires at least: 6.2
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 5.4.0.15
+Stable tag: 5.4.0.16
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -146,6 +146,11 @@ Yes, we have a quick FAQ with many more questions and answers [here](https://mai
 10. Dashboard Insights
 
 == Changelog ==
+
+= 5.4.0.16 - Maintenance Release - 7-15-2025 =
+
+* Fixed: Corrected the `[uptime.status]` token in Uptime Notification email subjects to display the accurate monitor status.
+* Fixed: Updated the Event time info in the Uptime Monitor email to display in the user's configured timezone instead of defaulting to UTC +0.
 
 = 5.4.0.15 - Maintenance Release - 7-8-2025 =
 

--- a/templates/emails/mainwp-uptime-monitoring-email.php
+++ b/templates/emails/mainwp-uptime-monitoring-email.php
@@ -83,7 +83,7 @@ if ( empty( $heading ) ) {
                             </tr>
                             <tr>
                                 <td style="vertical-align:top;text-align:left;padding:30px 30px 0 30px;">
-                                    <strong><?php esc_html_e( 'Event timestamp: ', 'mainwp' ); ?></strong><?php echo MainWP\Dashboard\MainWP_Utility::format_timestamp( $site->hb_time_check ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
+                                    <strong><?php esc_html_e( 'Event timestamp: ', 'mainwp' ); ?></strong><?php echo MainWP\Dashboard\MainWP_Utility::format_timezone( $site->hb_time_check, true ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
                                 </td>
                             </tr>
                                 <?php
@@ -119,7 +119,7 @@ if ( empty( $heading ) ) {
                                                 if ( ! empty( $site->hb_time_check ) ) {
                                                     $last_time = $site->hb_time_check;
                                                 }
-                                                echo MainWP\Dashboard\MainWP_Utility::format_timestamp( $last_time ); // phpcs:ignore WordPress.Security.EscapeOutput
+                                                echo MainWP\Dashboard\MainWP_Utility::format_timezone( $last_time, true ); // phpcs:ignore WordPress.Security.EscapeOutput
                                                 ?>
                                             </td>
                                         </tr>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the [uptime.status] token in Uptime Notification email subjects to accurately reflect the monitor status.
  * Event time in Uptime Monitor emails now displays according to your configured timezone instead of defaulting to UTC+0.

* **Improvements**
  * Enhanced email timestamp formatting to optionally include timezone information for improved clarity.
  * Improved uptime status detection by considering child site status for more accurate notifications.
  * Refined email notification timing and token preparation for better consistency.

* **Documentation**
  * Updated changelog and version numbers to 5.4.0.16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->