### PR TITLE
Ensure check_rest_api_enabled respects mainwp_sslVerifyCertificate op…

### DIFF
--- a/pages/page-mainwp-rest-api-page.php
+++ b/pages/page-mainwp-rest-api-page.php
@@ -1221,6 +1221,7 @@ class MainWP_Rest_Api_Page { // phpcs:ignore Generic.Classes.OpeningBraceSameLin
             'headers' => array(
                 'content-type' => 'application/json',
             ),
+            'sslverify' => (bool) get_option( 'mainwp_sslVerifyCertificate', true ),
         );
 
         if ( $check_logged_in && ! empty( $cookies ) ) {


### PR DESCRIPTION
When using MainWP REST API I expect it to respect the setting "Verify SSL certificate" (which translates to option "mainwp_sslVerifyCertificate").

However, the wp_remote_post used to check if the REST API is enabled does not follow the settings and will always try to verify the SSL certificate. This is particularly annoying in case one's using a self-signed certificate
