### PR TITLE
Mainwp 5.4.0.23 prepared

### DIFF
--- a/assets/css/mainwp.css
+++ b/assets/css/mainwp.css
@@ -657,6 +657,34 @@ table.mainwp-manage-updates-table tbody tr td .mainwp-update-selected-button {
 
 /* Manage Sites Table */
 
+.mainwp-flag-stack {
+    position: relative;
+    display: inline-block;
+    width: 2.2em;
+    height: 1.5em;
+    vertical-align: middle;
+}
+
+.mainwp-flag-stack__flag {
+    position: absolute;
+    display: inline-block;
+    transform: scale(0.88);
+}
+
+.mainwp-flag-stack__flag--primary {
+    top: -0.24em;
+    left: -0.36em;
+    transform-origin: top left;
+    z-index: 1;
+}
+
+.mainwp-flag-stack__flag--secondary {
+    right: -0.08em;
+    bottom: -0.04em;
+    transform-origin: bottom right;
+    z-index: 2;
+}
+
 table.mainwp-manage-wpsites-table {
     margin: 0;
 }

--- a/class/class-mainwp-cron-jobs-auto-updates.php
+++ b/class/class-mainwp-cron-jobs-auto-updates.php
@@ -127,6 +127,8 @@ class MainWP_Cron_Jobs_Auto_Updates { // phpcs:ignore Generic.Classes.OpeningBra
 
         $autoupdates_websites = MainWP_Auto_Updates_DB::instance()->get_websites_to_continue_updates( $sites_limit, $lasttime_start, false, true ); // included disconnected sites.
 
+        MainWP_Logger::instance()->log_events( 'debug-updates-crons', 'Auto updates :: found :: ' . ( ! empty( $autoupdates_websites ) ? count( $autoupdates_websites ) : 0 ) );
+
         if ( empty( $autoupdates_websites ) ) { // not found automatic sites to updates.
             $this->finished_auto_updates();
             MainWP_Logger::instance()->info( 'Automatic updates finished' );
@@ -149,8 +151,8 @@ class MainWP_Cron_Jobs_Auto_Updates { // phpcs:ignore Generic.Classes.OpeningBra
             $sync_before = apply_filters( 'mainwp_auto_updates_sync_data_before_run', true );
             foreach ( $autoupdates_websites as $website ) {
                 if ( ! empty( $website->sync_errors ) ) {
-                    if ( ! $sync_before || ! MainWP_Sync::sync_site( $website, false, true ) ) {
-                        $this->finished_site_auto_updates( $website );  // to skip.
+                    if ( ! MainWP_Sync::sync_site( $website, false, true ) ) {
+                        $this->finished_site_auto_updates( $website );  // to skip sync error sites.
                     }
                 } elseif ( $sync_before && ! MainWP_Sync::sync_site( $website, false, true ) ) {
                     $this->finished_site_auto_updates( $website );  // to skip.
@@ -164,6 +166,8 @@ class MainWP_Cron_Jobs_Auto_Updates { // phpcs:ignore Generic.Classes.OpeningBra
             MainWP_Logger::instance()->log_update_check( 'Automatic updates found [count=' . count( $autoupdates_websites ) . ']' . $log_lastsstart );
             unset( $autoupdates_websites );
         }
+
+        MainWP_Logger::instance()->log_events( 'debug-updates-crons', 'Auto updates :: running :: count :: ' . count( $websites ) );
 
         $count_processed_now = 0;
 
@@ -890,6 +894,8 @@ class MainWP_Cron_Jobs_Auto_Updates { // phpcs:ignore Generic.Classes.OpeningBra
                 }
             }
         }
+
+        MainWP_Logger::instance()->log_events( 'debug-updates-crons', 'Auto updates :: processed count :: ' . $count_processed_now );
 
         if ( ! empty( $finished_updates_sites ) ) {
             foreach ( $finished_updates_sites as $websiteId ) {

--- a/class/class-mainwp-manage-sites-backup-view.php
+++ b/class/class-mainwp-manage-sites-backup-view.php
@@ -102,7 +102,7 @@ class MainWP_Manage_Sites_Backup_View { // phpcs:ignore Generic.Classes.OpeningB
 
         <div class="ui modal" id="managesite-backup-status-box">
             <div class="header">
-                <?php echo esc_html_e( 'Backup ', 'mainwp' ); ?><?php echo esc_html( stripslashes( $website->name ) ); ?>
+                <?php esc_html_e( 'Backup ', 'mainwp' ); ?><?php echo esc_html( stripslashes( $website->name ) ); ?>
             </div>
             <div class="scrolling content mainwp-modal-content">
             </div>

--- a/class/class-mainwp-manage-sites-list-table.php
+++ b/class/class-mainwp-manage-sites-list-table.php
@@ -1739,12 +1739,12 @@ class MainWP_Manage_Sites_List_Table { // phpcs:ignore Generic.Classes.OpeningBr
                         <div class="ui checkbox"><input type="checkbox" value="<?php echo intval( $website['id'] ); ?>" /></div>
                     <?php } elseif ( 'status' === $column_name ) { ?>
                         <?php if ( $hasSyncErrors ) : ?>
-                            <span data-tooltip="<?php echo esc_attr_e( 'Disconnected', 'mainwp' ); ?>" data-position="right center" data-inverted=""><a class="mainwp_site_reconnect" href="#"><i class="red times large icon"></i></a></span>
+                            <span data-tooltip="<?php esc_attr_e( 'Disconnected', 'mainwp' ); ?>" data-position="right center" data-inverted=""><a class="mainwp_site_reconnect" href="#"><i class="red times large icon"></i></a></span>
                         <?php else : ?>
                             <?php if ( $suspendedSite ) : ?>
-                                <span data-tooltip="<?php echo esc_attr_e( 'Suspended', 'mainwp' ); ?>" data-position="right center" data-inverted=""><a class="managesites_syncdata" href="#"><i class="pause yellow large icon"></i></a></span>
+                                <span data-tooltip="<?php esc_attr_e( 'Suspended', 'mainwp' ); ?>" data-position="right center" data-inverted=""><a class="managesites_syncdata" href="#"><i class="pause yellow large icon"></i></a></span>
                             <?php else : ?>
-                                <span data-tooltip="<?php echo esc_attr_e( 'Connected', 'mainwp' ); ?>" data-position="right center" data-inverted=""><a class="managesites_syncdata" href="#"><i class="green large check icon"></i></a></span>
+                                <span data-tooltip="<?php esc_attr_e( 'Connected', 'mainwp' ); ?>" data-position="right center" data-inverted=""><a class="managesites_syncdata" href="#"><i class="green large check icon"></i></a></span>
                             <?php endif; ?>
                         <?php endif; ?>
                     <?php } elseif ( 'favicon' === $column_name ) { ?>

--- a/class/class-mainwp-system.php
+++ b/class/class-mainwp-system.php
@@ -29,7 +29,7 @@ class MainWP_System { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Conte
      *
      * @var string Current plugin version.
      */
-    public static $version = '5.4.0.22'; // NOSONAR.
+    public static $version = '5.4.0.23'; // NOSONAR.
 
     /**
      * Private static variable to hold the single instance of the class.

--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -1860,6 +1860,26 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
             $lowercase_last_two_chars = 'dz';
         }
 
+        $stacked_flags = array(
+            'ca' => array(
+                'primary'   => 'es',
+                'secondary' => 'ad',
+            ),
+        );
+
+        if ( isset( $stacked_flags[ $lowercase_last_two_chars ] ) ) {
+            $primary_flag   = $stacked_flags[ $lowercase_last_two_chars ]['primary'];
+            $secondary_flag = $stacked_flags[ $lowercase_last_two_chars ]['secondary'];
+
+            echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted="">';
+            echo '<span class="mainwp-flag-stack">';
+            echo '<i class="small ' . esc_attr( $primary_flag ) . ' flag mainwp-flag-stack__flag mainwp-flag-stack__flag--primary"></i>';
+            echo '<i class="small ' . esc_attr( $secondary_flag ) . ' flag mainwp-flag-stack__flag mainwp-flag-stack__flag--secondary"></i>';
+            echo '</span>';
+            echo '</span>';
+            return;
+        }
+
         echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted=""><i class="small ' . esc_attr( $lowercase_last_two_chars ) . ' flag"></i></span>';
     }
 

--- a/class/class-mainwp-utility.php
+++ b/class/class-mainwp-utility.php
@@ -1845,6 +1845,7 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
         $last_two_chars = ! empty( $flag_language ) ? substr( $flag_language, -2 ) : '';
         // Convert to lowercase.
         $lowercase_last_two_chars = strtolower( $last_two_chars );
+        $lowercase_flag_language  = strtolower( $flag_language );
 
         // Get display name using the original language string.
         $display_language = function_exists( 'locale_get_display_name' ) ? locale_get_display_name( $language ) : $language;
@@ -1866,18 +1867,31 @@ class MainWP_Utility { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
                 'secondary' => 'ad',
             ),
         );
+        // Only stack flags for explicit Catalan locales to avoid affecting Canada.
+        $stacked_flag_locales = array(
+            'ca' => array(
+                'ca',
+            ),
+        );
 
         if ( isset( $stacked_flags[ $lowercase_last_two_chars ] ) ) {
-            $primary_flag   = $stacked_flags[ $lowercase_last_two_chars ]['primary'];
-            $secondary_flag = $stacked_flags[ $lowercase_last_two_chars ]['secondary'];
+            $should_stack = true;
+            if ( isset( $stacked_flag_locales[ $lowercase_last_two_chars ] ) ) {
+                $should_stack = in_array( $lowercase_flag_language, $stacked_flag_locales[ $lowercase_last_two_chars ], true );
+            }
 
-            echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted="">';
-            echo '<span class="mainwp-flag-stack">';
-            echo '<i class="small ' . esc_attr( $primary_flag ) . ' flag mainwp-flag-stack__flag mainwp-flag-stack__flag--primary"></i>';
-            echo '<i class="small ' . esc_attr( $secondary_flag ) . ' flag mainwp-flag-stack__flag mainwp-flag-stack__flag--secondary"></i>';
-            echo '</span>';
-            echo '</span>';
-            return;
+            if ( $should_stack ) {
+                $primary_flag   = $stacked_flags[ $lowercase_last_two_chars ]['primary'];
+                $secondary_flag = $stacked_flags[ $lowercase_last_two_chars ]['secondary'];
+
+                echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted="">';
+                echo '<span class="mainwp-flag-stack">';
+                echo '<i class="small ' . esc_attr( $primary_flag ) . ' flag mainwp-flag-stack__flag mainwp-flag-stack__flag--primary"></i>';
+                echo '<i class="small ' . esc_attr( $secondary_flag ) . ' flag mainwp-flag-stack__flag mainwp-flag-stack__flag--secondary"></i>';
+                echo '</span>';
+                echo '</span>';
+                return;
+            }
         }
 
         echo '<span data-tooltip="' . esc_html__( 'Site Language: ', 'mainwp' ) . esc_attr( $display_language ) . '" data-position="left center" data-inverted=""><i class="small ' . esc_attr( $lowercase_last_two_chars ) . ' flag"></i></span>';

--- a/includes/rest-api/class-mainwp-rest-authentication.php
+++ b/includes/rest-api/class-mainwp-rest-authentication.php
@@ -149,11 +149,32 @@ class MainWP_REST_Authentication { //phpcs:ignore -- NOSONAR - maximumMethodThre
      * @return bool
      */
     private function is_ssl_request() {
-        if ( is_ssl() || wp_is_using_https() ) {
+        if ( is_ssl() || wp_is_using_https() || $this->is_local_request() ) {
             return true;
         }
         return false;
     }
+
+    /**
+     * Method is_local_request().
+     *
+     * @return bool
+     */
+    private function is_local_request() {
+
+        if ( ! isset( $_SERVER['REMOTE_ADDR'] ) ) {
+            return false;
+        }
+
+        $ip = $_SERVER['REMOTE_ADDR']; //phpcs:ignore -- ok.
+
+        // Always allow localhost.
+        if ( '127.0.0.1' === $ip || '::1' === $ip ) {
+            return true;
+        }
+        return false;
+    }
+
 
     /**
      * Authenticate the user if authentication wasn't performed during the

--- a/includes/rest-api/controller/version2/class-mainwp-rest-sites-controller.php
+++ b/includes/rest-api/controller/version2/class-mainwp-rest-sites-controller.php
@@ -1111,7 +1111,7 @@ class MainWP_Rest_Sites_Controller extends MainWP_REST_Controller{ //phpcs:ignor
             $data    = array();
 
             if ( 'delete' === $action && is_array( $information ) && ! empty( $information['error']['is_activated_theme'] ) ) {
-                $data['error'] = esc_html__( sprintf( 'The theme %s is active.', $information['error']['is_activated_theme'] ), 'mainwp' );
+                $data['error'] = sprintf( esc_html__( 'The theme %s is active.', 'mainwp' ), $information['error']['is_activated_theme'] );
             }
 
             if ( 'activate' === $action && isset( $information['other_data']['theme_deactivate_data'] ) ) {

--- a/mainwp.php
+++ b/mainwp.php
@@ -8,7 +8,7 @@
  * Author URI: https://mainwp.com
  * Plugin URI: https://mainwp.com/
  * Text Domain: mainwp
- * Version:  5.4.0.22
+ * Version:  5.4.0.23
  *
  * @package MainWP/Dashboard
  *

--- a/pages/page-mainwp-client.php
+++ b/pages/page-mainwp-client.php
@@ -1796,7 +1796,7 @@ class MainWP_Client { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Conte
                     <?php
                     $indi_val = $edit_client && $client_contacts ? 1 : 0;
                     MainWP_Settings_Indicator::render_not_default_indicator( 'none_preset_value', $indi_val );
-                    echo esc_html_e( 'Client primary contact', 'mainwp' );
+                    esc_html_e( 'Client primary contact', 'mainwp' );
                     ?>
                     </label>
                     <div class="ui six wide column">

--- a/pages/page-mainwp-updates-per-group.php
+++ b/pages/page-mainwp-updates-per-group.php
@@ -84,7 +84,7 @@ class MainWP_Updates_Per_Group { // phpcs:ignore Generic.Classes.OpeningBraceSam
                                 </div>
 
                             </td>
-                            <td sort-value="0"><span total-uid="uid_wp_upgrades_<?php echo esc_attr( $group_id ); ?>" data-inverted="" data-tooltip="<?php echo esc_attr( esc_html__( 'Click to see available updates', 'mainwp' ) ); ?>"></span></td>
+                            <td sort-value="0"><span total-uid="uid_wp_upgrades_<?php echo esc_attr( $group_id ); ?>" data-inverted="" data-tooltip="<?php esc_attr_e( 'Click to see available updates', 'mainwp' ); ?>"></span></td>
                             <td class="right aligned">
                                 <?php if ( MainWP_Updates::user_can_update_wp() ) : ?>
                                     <a href="javascript:void(0)" data-tooltip="<?php esc_attr_e( 'Update all sites in the tag', 'mainwp' ); ?>" data-inverted="" data-position="left center" btn-all-uid2="uid_wp_upgrades_<?php echo esc_attr( $group_id ); ?>" class="mainwp-update-selected-button ui basic green mini button" onClick="event.stopPropagation();updatesoverview_wordpress_global_upgrade_all( <?php echo esc_attr( $group_id ); ?>, true );  return false;"><?php esc_html_e( 'Update Selected', 'mainwp' ); ?></a>

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Plugin URI: https://mainwp.com
 Requires at least: 6.2
 Tested up to: 6.8.2
 Requires PHP: 7.4
-Stable tag: 5.4.0.22
+Stable tag: 5.4.0.23
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -146,6 +146,13 @@ Yes, we have a quick FAQ with many more questions and answers [here](https://mai
 10. Dashboard Insights
 
 == Changelog ==
+
+= 5.4.0.23 - Maintenance Release - 10-7-2025 =
+
+* Fixed: Corrected the flag icon displayed for the Catalan (ca) locale. [(#839)](https://github.com/mainwp/mainwp/issues/839)
+* Updated: Implemented small improvements to enhance the reliability of automatic updates across different server environments.
+* Updated: Enabled REST API v2 requests over HTTP protocol on localhost setups to facilitate local development and testing.
+* Updated: Standardized translation and escaping functions to ensure more reliable and consistent text formatting throughout the Dashboard ([PR838](https://github.com/mainwp/mainwp/pull/481)) - thanks [DAnn2012](https://github.com/DAnn2012)
 
 = 5.4.0.22 - Maintenance Release - 9-23-2025 =
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stacked language flags and a flag-stack visual in the Manage Sites table for clearer site language/status display.

* **Bug Fixes**
  * Removed duplicate/incorrect label and modal header output so text renders once.
  * Corrected tooltip and update-cell text rendering for site statuses.
  * Ensured “Client primary contact” label displays reliably.
  * Fixed translation/formatting of the theme deletion error message.

* **Improvements**
  * Improved automatic-update logging and reliability across environments.
  * Treat local (localhost) requests as secure to enable REST API v2 over HTTP for local development.

* **Chores**
  * Bumped plugin version and release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->