### PR TITLE
OAuth changed to Personal Access Token

### DIFF
--- a/modules/api-backups/classes/class-api-backups-settings.php
+++ b/modules/api-backups/classes/class-api-backups-settings.php
@@ -538,7 +538,7 @@ class Api_Backups_Settings {
                             </h3>
                             <ul>
                                 <li><?php printf( esc_html__( "1. If you don't already have one, get a %s", 'mainwp' ), '<a target="_blank" href="https://mainwp.com/go/digital-ocean/">DigitalOcean account</a>' ); // NOSONAR - noopener - open safe. ?></li>
-                                <li><?php printf( esc_html__( '2. You can generate an %1$sOAuth token%2$s by visiting the %3$s section of the DigitalOcean control panel for your account.', 'mainwp' ), '<b>', '</b>', '<a target="_blank" href="https://cloud.digitalocean.com/account/api/tokens">Apps & API</a>' ); ?></b></li>
+				<li><?php printf( esc_html__( '2. You can generate a %1$sPersonal Access Token%2$s by visiting the %3$s section of the DigitalOcean control panel for your account.', 'mainwp' ), '<b>', '</b>', '<a target="_blank" href="https://cloud.digitalocean.com/account/api/tokens">Apps & API</a>' ); ?></b></li>
                                 <li><?php printf( esc_html__( '3. Paste in your %1$sPersonal Access Token%2$s below and click the Save Settings button.', 'mainwp' ), '<b>', '</b>' ); ?></li>
                                 <li><?php esc_html_e( '4. Once the API is connected, go to the Site Edit page (for all sites on this host) and set the correct Provider and Instance ID.', 'mainwp' ); ?></li>
                             </ul>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the DigitalOcean integration instructions to reference a Personal Access Token instead of an OAuth token. This clarifies the required credential type in the backups settings, reducing setup confusion. No functional behavior changed, and existing configurations continue to work. Users only need to take note if generating new tokens; otherwise, no action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->