### PR TITLE
Improve: datepicker enable select for custom network activities filter

### DIFF
--- a/modules/logs/pages/page-log-manage-insights-events-page.php
+++ b/modules/logs/pages/page-log-manage-insights-events-page.php
@@ -736,6 +736,11 @@ class Log_Manage_Insights_Events_Page { // phpcs:ignore Generic.Classes.OpeningB
                     }
                 });
 
+                if($( '#mainwp-module-log-filter-ranges').length && 'custom' === $( '#mainwp-module-log-filter-ranges').dropdown('get value') && dateRanges?.custom?.start !== undefined ){
+                    $('#mainwp-module-log-filter-dtsstart').calendar('set date', dateRanges['custom']['start']);
+                    $('#mainwp-module-log-filter-dtsstop').calendar('set date', dateRanges['custom']['end']);
+                }
+
                 mainwp_module_log_manage_events_filter = function() {
                     let range = jQuery( '#mainwp-module-log-filter-ranges').dropdown('get value');
                     let group = jQuery( '#mainwp-module-log-filter-groups').dropdown('get value');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom date range calendars in the log management page now automatically pre-populate with the correct start and end dates when a custom date range is selected from the log range selector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->