### PR TITLE
Use prepared statement for SQL query in MainWP_DB

### DIFF
--- a/class/class-mainwp-db.php
+++ b/class/class-mainwp-db.php
@@ -2209,7 +2209,7 @@ class MainWP_DB extends MainWP_DB_Base { // phpcs:ignore Generic.Classes.Opening
 
         $sql .= ' ' . $where;
 
-        return $this->wpdb->get_results( $sql, OBJECT ); // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $where fragment is from validated get_sql_where_access_sites() with numeric IDs
+        return $this->wpdb->get_results( $this->wpdb->prepare( $sql, ...$params ), OBJECT ); // phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $where fragment is from validated get_sql_where_access_sites() with numeric IDs
     }
 
     /**


### PR DESCRIPTION
Updated the get_results call to use $wpdb->prepare for improved security by parameterizing the SQL query with $params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database query security through improved parameter handling in data retrieval operations, strengthening the overall stability and safety of database interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->