### PR TITLE
Ensure sleep time is non-negative

### DIFF
--- a/class/class-mainwp-connect.php
+++ b/class/class-mainwp-connect.php
@@ -1871,7 +1871,7 @@ class MainWP_Connect { // phpcs:ignore Generic.Classes.OpeningBraceSameLine.Cont
         if ( $lastRequest > ( ( microtime( true ) ) - $minimumDelay ) ) {
             static::release( $identifier );
             $sleep = ( $minimumDelay - ( ( microtime( true ) ) - $lastRequest ) ) * 1000 * 1000;
-            $sleep = intval( $sleep );
+            $sleep = max( 0, intval( $sleep ) );
             usleep( $sleep );
             return true;
         }


### PR DESCRIPTION
In `class-mainwp-connect.php`, the method `check_constraints_last_request()` calculates a sleep duration based on the difference between `$minimumDelay` and the elapsed time since `$lastRequest`. However, there is a race condition between the `if` check on line 1871 and the sleep calculation on line 1874: time passes between these two statements, so by the time `$sleep` is computed, `microtime(true) - $lastRequest` may have exceeded `$minimumDelay`, resulting in a negative value.

On PHP 8.0+, passing a negative value to `usleep()` throws a `ValueError`:

```
PHP Fatal error: Uncaught ValueError: usleep(): Argument #1 ($microseconds) must be greater than or equal to 0
in class/class-mainwp-connect.php:1875
```

This crashes the sync request. Because the rate-limiting logic fails mid-execution, subsequent sync requests can stall and time out (we observed 121-second LSAPI timeouts on LiteSpeed), causing slow or failed syncs across all connected child sites.

## Steps to reproduce

1. Run MainWP Dashboard 6.0.6 on PHP 8.4
2. Trigger a sync (manual or automatic) for multiple sites
3. Under certain timing conditions, the calculated sleep value becomes negative
4. PHP throws a `ValueError`, the sync request dies, and follow-up requests time out

## Suggested fix

Clamp the sleep value to a minimum of 0 before passing it to `usleep()`:

```php
// Before (line 1875):
$sleep = intval( $sleep );

// After:
$sleep = max( 0, intval( $sleep ) );
```

This ensures that if the delay has already elapsed by the time the calculation runs, `usleep()` simply receives 0 instead of a negative value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where request timing constraints could produce invalid sleep intervals, ensuring consistent request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->